### PR TITLE
fix: serialize Decimal results for Docker demos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.venv
+.env
+.env.*
+.sql2json
+sql2json.json
+dist
+*.egg-info
+test.db
+*.db
+*.sqlite
+*.sqlite3
+.pytest_cache
+__pycache__
+*.pyc
+.pre-commit-config.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ uv run black .
 
 # Run the CLI tool
 python -m sql2json --name default --query default
+
+# Build Docker image
+docker build -t sql2json .
 ```
 
 ## Architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /src
+COPY . /src
+RUN pip install --no-cache-dir . psycopg2-binary PyMySQL
+
+WORKDIR /workspace
+
+ENTRYPOINT ["python", "-m", "sql2json"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,103 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 pip install sql2json
 ```
 
+## Docker
+
+The image includes drivers for PostgreSQL (`psycopg2-binary`) and MySQL / MariaDB (`PyMySQL`) in addition to SQLite, which is built into Python.
+
+Build the image from the repository root:
+
+```bash
+docker build -t sql2json .
+```
+
+Quick test without a config file:
+
+```bash
+docker run --rm sql2json --query "SELECT 1 AS a, 2 AS b"
+# → [{"a": 1, "b": 2}]
+```
+
+Run with your own config by mounting `~/.sql2json`:
+
+```bash
+docker run --rm \
+  -v ~/.sql2json:/root/.sql2json \
+  sql2json --name default --query sales_monthly --date_from "START_CURRENT_MONTH-1"
+```
+
+For SQLite, mount both the config directory and the database file. Point the connection string in your config to the in-container path:
+
+```bash
+docker run --rm \
+  -v ~/.sql2json:/root/.sql2json \
+  -v /path/to/mydb.sqlite:/data/mydb.sqlite \
+  sql2json --name default --query default
+```
+
+```json
+{
+    "connections": {
+        "default": "sqlite:////data/mydb.sqlite"
+    }
+}
+```
+
+Write output files by mounting a host directory to `/workspace`, the container working directory:
+
+```bash
+docker run --rm \
+  -v ~/.sql2json:/root/.sql2json \
+  -v $(pwd)/reports:/workspace \
+  sql2json --name default --query sales_monthly \
+    --format csv --output "Sales_{CURRENT_DATE}"
+# → ./reports/Sales_2026-05-17.csv on the host
+```
+
+MS SQL Server needs system-level ODBC libraries, so install the driver in a derived image:
+
+```dockerfile
+FROM sql2json
+RUN pip install --no-cache-dir pyodbc
+```
+
+### Try it with docker compose
+
+The repo includes a `docker-compose.yml` that starts PostgreSQL and MySQL with demo-only credentials, a small `sales` table, and a pre-wired `docker/config.json`. The database ports bind to `127.0.0.1` for local testing.
+
+Start the databases:
+
+```bash
+docker compose up -d postgres mysql
+```
+
+Run queries against PostgreSQL:
+
+```bash
+docker compose run --rm sql2json --name pg --query version
+# → [{"version": "PostgreSQL 16.x ..."}]
+
+docker compose run --rm sql2json --name pg --query sales
+# → [{"id": 1, "month": "January", "amount": 5000.0}, ...]
+
+docker compose run --rm sql2json --name pg --query sales_by_month --min_amount 4000
+# → [{"month": "January", "amount": 5000.0}, {"month": "March", "amount": 7100.75}]
+```
+
+Run the same demo queries against MySQL by switching `--name`:
+
+```bash
+docker compose run --rm sql2json --name mysql --query sales
+```
+
+Tear down when done:
+
+```bash
+docker compose down
+```
+
+The demo config lives in `docker/config.json` and the seed table in `docker/initdb.sql`.
+
 ## Quick start
 
 **1. Create the config file:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  postgres:
+    image: docker.io/library/postgres:16-alpine
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo
+      POSTGRES_DB: demo
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - ./docker/initdb.sql:/docker-entrypoint-initdb.d/01-demo.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U demo"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mysql:
+    image: docker.io/library/mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: demo
+      MYSQL_USER: demo
+      MYSQL_PASSWORD: demo
+    ports:
+      - "127.0.0.1:3306:3306"
+    volumes:
+      - ./docker/initdb.sql:/docker-entrypoint-initdb.d/01-demo.sql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  sql2json:
+    build: .
+    volumes:
+      - ./docker/config.json:/root/.sql2json/config.json
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,0 +1,11 @@
+{
+    "connections": {
+        "pg": "postgresql+psycopg2://demo:demo@postgres/demo",
+        "mysql": "mysql+pymysql://demo:demo@mysql/demo"
+    },
+    "queries": {
+        "version": "SELECT version() AS version",
+        "sales": "SELECT * FROM sales",
+        "sales_by_month": "SELECT month, amount FROM sales WHERE amount >= :min_amount"
+    }
+}

--- a/docker/initdb.sql
+++ b/docker/initdb.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS sales (
+    id    INT,
+    month VARCHAR(20),
+    amount DECIMAL(10, 2)
+);
+
+INSERT INTO sales (id, month, amount) VALUES
+    (1, 'January',  5000.00),
+    (2, 'February', 3200.50),
+    (3, 'March',    7100.75);

--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import csv
 import json
 import sys
+from decimal import Decimal
 
 import fire
 
@@ -28,6 +29,16 @@ def parse_filename(file_name, current_date):
     return "".join(results)
 
 
+def json_default(value):
+    if isinstance(value, Decimal):
+        return float(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def json_dumps(value):
+    return json.dumps(value, default=json_default)
+
+
 def save_json(rows, file_name, timezone=None):
     current_date = _current_date(timezone)
     parsed_filename = parse_filename(file_name, current_date)
@@ -37,7 +48,7 @@ def save_json(rows, file_name, timezone=None):
     )
 
     with open(final_file_name, "w") as outfile:
-        json.dump(rows, outfile)
+        outfile.write(json_dumps(rows))
 
 
 def save_csv(rows, file_name, dialect, key, timezone=None):
@@ -119,11 +130,11 @@ def handle_run_query2json(
                 save_json(result, output, timezone=timezone)
         else:
             if key and value and first:
-                print(json.dumps(result))
+                print(json_dumps(result))
             elif key and first:
                 print(result)
             else:
-                print(json.dumps(result))
+                print(json_dumps(result))
 
     except Exception as e:
         print(json.dumps({"error": str(e), "type": type(e).__name__}), file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from decimal import Decimal
 
 import pytest
 
@@ -59,6 +60,13 @@ class TestDefaultQuery:
         assert result.returncode == 0
         rows = json.loads(result.stdout)
         assert rows[0]["val"] == 99
+
+    def test_decimal_results_are_json_serializable(self):
+        from sql2json.__main__ import json_dumps
+
+        rows = [{"amount": Decimal("5000.00")}]
+
+        assert json_dumps(rows) == '[{"amount": 5000.0}]'
 
 
 class TestListConnections:


### PR DESCRIPTION
## Summary
- Add Decimal-aware JSON output for CLI stdout and JSON file writes
- Add Dockerfile, docker-compose demo services, and sample Postgres/MySQL config
- Document Docker usage and local compose demo commands

## Test Plan
- HOME=/tmp/sql2json-fra151-home-* uv run --extra dev pytest --tb=short -q
- docker build -t sql2json-fra-151 .
- docker run --rm sql2json-fra-151 --query "SELECT 1 AS a, 2 AS b"
- docker compose config
- docker compose run --rm sql2json --name pg --query sales
- docker compose run --rm sql2json --name mysql --query sales
- docker compose run --rm sql2json --name pg --query sales_by_month --min_amount 4000

Linear: FRA-151
