### PR TITLE
test: isolate suite from user ~/.sql2json/config.json (FRA-153)

### DIFF
--- a/sql2json/sql2json.py
+++ b/sql2json/sql2json.py
@@ -40,7 +40,7 @@ def load_config_file(config_path: str) -> dict:
         pass
 
     return {
-        "conections": {"default": "sqlite:///test.db"},
+        "conections": {"default": "sqlite:///:memory:"},
         "queries": {"default": "SELECT 1 AS a, 2 AS b"},
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Keep tests independent of ~/.sql2json/config.json on the developer's machine.
+
+    _find_config() searches HOME last. Without this fixture it finds the real user
+    config, causing tests that rely on the built-in SQLite fallback to fail or
+    produce machine-specific results.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- Adds `tests/conftest.py` with an `autouse` fixture that patches `HOME` to a fresh `tmp_path` per test, so `_find_config()` never resolves `~/.sql2json/config.json` during the test run
- Fixes the no-config fallback connection string from `sqlite:///test.db` (file-based, created stray `test.db` in CWD) to `sqlite:///:memory:` — matching the documented behavior

## Root cause

`_find_config()` walks three locations in order: `./sql2json.json`, `./.sql2json/config.json`, then `~/.sql2json/config.json`. On a developer machine the third path exists and its `default` connection can point to a missing or incompatible database. Six tests in `test_sql2json.py` relied on the in-memory fallback but instead hit the real user config and failed with `OperationalError`.

## Test plan

- [x] `uv run pytest` passes with 66/66 under normal `HOME` (previously 6 failed)
- [x] Confirm `test.db` is no longer created in the repo root after a test run
- [x] `test_discovery.py::TestFindConfig` tests still pass — `monkeypatch.setenv("HOME", ...)` is compatible with the existing `monkeypatch.chdir()` calls in those tests