### PR TITLE
FRA-165: Define public Python API boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > supported public entry point. `sql2json` is pre-1.0, so this ships as a
 > minor bump with **no formal deprecation cycle**.
 >
-> The API-boundary work (privatizing helpers, adding `__all__`, and
-> single-sourcing the version via `importlib.metadata.version("sql2json")`)
-> will land as part of this release; its CHANGELOG entries land with that change.
+> This release includes API-boundary work: privatizing helpers, adding
+> explicit `__all__` exports, and single-sourcing the package version via
+> `importlib.metadata.version("sql2json")`.
 >
 > **Migration:** if you imported any of those date helpers from
 > `sql2json.parameter`, switch to the public `parse_parameter` for
 > date-variable resolution.
 
 ### Added
+- Explicit `__all__` exports for the supported top-level Python API and `sql2json.parameter` surface.
+- Python API documentation and runnable examples under `examples/python_api`.
 - `--timezone` flag: accepts an IANA timezone name (e.g. `--timezone America/New_York`, `--timezone UTC`) and uses it when resolving `CURRENT_DATE`, `START_CURRENT_MONTH`, and all other date variables. Defaults to local system timezone (backward-compatible). An invalid timezone name produces a structured JSON error on stderr and a non-zero exit code.
+
+### Changed
+- Package version is now single-sourced from installed package metadata via `importlib.metadata.version("sql2json")`.
+- `sql2json.parameter` now only exports the public `parse_parameter` entry point; lower-level date helper functions are private implementation details.
 
 ## [0.1.11] - 2026-05-16
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,25 @@ Supported public imports are exported from `sql2json.__all__`. Internal helpers 
 
 See [examples/python_api](examples/python_api) for runnable examples covering named queries, inline SQL, discovery, output shapes, JSON columns, date parameters, SQL files, and exception handling.
 
+### Public API surface
+
+`sql2json` treats the following as its supported, public surface. Everything else is an implementation detail that may change without notice.
+
+**Python API** — the names exported from `sql2json.__all__`:
+
+- `run_query2json`, `run_query_by_name`
+- `list_connections`, `list_queries`
+- `parse_parameter` (from `sql2json.parameter`)
+- `__version__`
+
+**CLI compatibility contract** — the supported, stable CLI behavior:
+
+- Documented flags: `--name`, `--query`, plus `--first`, `--key`, `--value`, `--wrapper`, `--jsonkeys`, `--format`, `--output`, `--timezone`, and arbitrary `--<bind_param>` values.
+- Output shapes: JSON to stdout (default), CSV and Excel via `--format`/`--output`.
+- Error contract: a structured JSON error envelope on stderr with a non-zero exit code.
+
+**Versioning:** `sql2json` is pre-1.0 (`0.x`) and carries **no API stability guarantee** under SemVer — breaking changes ship in a minor bump (e.g. `0.1.x → 0.2.0`), not a major. A real stability contract would be an explicit `1.0.0` decision.
+
 ## For AI agents
 
 `sql2json` is designed to be called as a subprocess by AI agents and LLMs. It outputs clean JSON to stdout, structured errors to stderr, and supports discovery commands so an agent can orient itself before querying.

--- a/README.md
+++ b/README.md
@@ -369,6 +369,32 @@ python -m sql2json --name mysql --query sales_monthly --date_from "CURRENT_DATE"
 
 > **Note:** CSV requires `--output` (it cannot be written to stdout).
 
+## Python API
+
+The supported Python API mirrors the user-facing CLI capabilities while keeping implementation details private:
+
+```python
+from sql2json import list_connections, list_queries, run_query2json, run_query_by_name
+
+rows = run_query2json(
+    name="sqlite:///:memory:",
+    query="SELECT :person_name AS name, :score AS score",
+    person_name="Ada",
+    score=42,
+)
+
+connections = list_connections("/path/to/config.json")
+queries = list_queries("/path/to/config.json")
+```
+
+Use `run_query2json()` for inline SQL, named queries, SQL files with `@/path.sql`, bind/date parameters, `first`, `key`, `value`, `wrapper`, `jsonkeys`, and `timezone`. Use `run_query_by_name()` when you specifically want the lower-level named connection/query call.
+
+Python API errors are normal Python exceptions. The CLI-only JSON stderr envelope is not used by the Python API.
+
+Supported public imports are exported from `sql2json.__all__`. Internal helpers in `sql2json.sql2json`, `sql2json.__main__`, or `sql2json.parameter.parameter_parser` are implementation details and should not be imported by users. `sql2json.parameter.parse_parameter` remains public for date-variable resolution; lower-level date helper functions are private.
+
+See [examples/python_api](examples/python_api) for runnable examples covering named queries, inline SQL, discovery, output shapes, JSON columns, date parameters, SQL files, and exception handling.
+
 ## For AI agents
 
 `sql2json` is designed to be called as a subprocess by AI agents and LLMs. It outputs clean JSON to stdout, structured errors to stderr, and supports discovery commands so an agent can orient itself before querying.

--- a/examples/python_api/README.md
+++ b/examples/python_api/README.md
@@ -1,0 +1,26 @@
+# Python API examples
+
+These examples show how to use the supported `sql2json` Python API without relying on private implementation details.
+
+Run from the repository root with:
+
+```bash
+uv run python examples/python_api/run_inline_sql.py
+uv run python examples/python_api/output_shapes.py
+uv run python examples/python_api/list_config.py
+uv run python examples/python_api/run_named_query.py
+uv run python examples/python_api/json_columns.py
+uv run python examples/python_api/date_parameters.py
+uv run python examples/python_api/sql_file.py
+uv run python examples/python_api/error_handling.py
+```
+
+Public API used here:
+
+- `run_query2json`
+- `run_query_by_name`
+- `list_connections`
+- `list_queries`
+- `parse_parameter`
+
+Implementation helpers inside `sql2json.sql2json`, `sql2json.__main__`, or `sql2json.parameter.parameter_parser` are internal and should not be imported by users.

--- a/examples/python_api/date_parameters.py
+++ b/examples/python_api/date_parameters.py
@@ -1,0 +1,11 @@
+from sql2json import run_query2json
+
+rows = run_query2json(
+    name="sqlite:///:memory:",
+    query="SELECT :start_date AS start_date, :end_date AS end_date",
+    timezone="UTC",
+    start_date="START_CURRENT_MONTH|%Y-%m-%d 00:00:00",
+    end_date="END_CURRENT_MONTH|%Y-%m-%d 23:59:59",
+)
+
+print(rows)

--- a/examples/python_api/error_handling.py
+++ b/examples/python_api/error_handling.py
@@ -1,0 +1,11 @@
+from sqlalchemy.exc import SQLAlchemyError
+
+from sql2json import run_query2json
+
+try:
+    run_query2json(
+        name="sqlite:///:memory:",
+        query="SELECT * FROM missing_table",
+    )
+except SQLAlchemyError as exc:
+    print(type(exc).__name__)

--- a/examples/python_api/json_columns.py
+++ b/examples/python_api/json_columns.py
@@ -1,0 +1,9 @@
+from sql2json import run_query2json
+
+rows = run_query2json(
+    name="sqlite:///:memory:",
+    query="SELECT json_object('name', 'Ada', 'active', 1) AS payload",
+    jsonkeys="payload",
+)
+
+print(rows)

--- a/examples/python_api/list_config.py
+++ b/examples/python_api/list_config.py
@@ -1,0 +1,17 @@
+import json
+import tempfile
+from pathlib import Path
+
+from sql2json import list_connections, list_queries
+
+config = {
+    "connections": {"default": "sqlite:///:memory:", "reporting": "sqlite:///:memory:"},
+    "queries": {"default": "SELECT 1 AS ok", "sales": "SELECT 42 AS total"},
+}
+
+with tempfile.TemporaryDirectory() as tmp:
+    config_path = Path(tmp) / "sql2json.json"
+    config_path.write_text(json.dumps(config))
+
+    print(list_connections(str(config_path)))
+    print(list_queries(str(config_path)))

--- a/examples/python_api/output_shapes.py
+++ b/examples/python_api/output_shapes.py
@@ -1,0 +1,10 @@
+from sql2json import run_query2json
+
+query = "SELECT 'January' AS month, 5000 AS sales UNION ALL SELECT 'February', 3000"
+
+print(run_query2json(name="sqlite:///:memory:", query=query, first=True))
+print(run_query2json(name="sqlite:///:memory:", query=query, first=True, key="sales"))
+print(
+    run_query2json(name="sqlite:///:memory:", query=query, key="month", value="sales")
+)
+print(run_query2json(name="sqlite:///:memory:", query=query, wrapper=True))

--- a/examples/python_api/run_inline_sql.py
+++ b/examples/python_api/run_inline_sql.py
@@ -1,0 +1,8 @@
+from sql2json import run_query2json
+
+rows = run_query2json(
+    name="sqlite:///:memory:",
+    query="SELECT 1 AS id, 'Ada' AS name",
+)
+
+print(rows)

--- a/examples/python_api/run_named_query.py
+++ b/examples/python_api/run_named_query.py
@@ -1,0 +1,23 @@
+import json
+import tempfile
+from pathlib import Path
+
+from sql2json import run_query_by_name
+
+config = {
+    "connections": {"default": "sqlite:///:memory:"},
+    "queries": {"answer": "SELECT :value AS value"},
+}
+
+with tempfile.TemporaryDirectory() as tmp:
+    config_path = Path(tmp) / "sql2json.json"
+    config_path.write_text(json.dumps(config))
+
+    rows = run_query_by_name(
+        conection_name="default",
+        query_name="answer",
+        config=str(config_path),
+        value=42,
+    )
+
+print(rows)

--- a/examples/python_api/sql_file.py
+++ b/examples/python_api/sql_file.py
@@ -1,0 +1,16 @@
+import tempfile
+from pathlib import Path
+
+from sql2json import run_query2json
+
+with tempfile.TemporaryDirectory() as tmp:
+    sql_path = Path(tmp) / "query.sql"
+    sql_path.write_text("SELECT :answer AS answer")
+
+    rows = run_query2json(
+        name="sqlite:///:memory:",
+        query=f"@{sql_path}",
+        answer=123,
+    )
+
+print(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sql2json"
-version = "0.1.11"
+version = "0.2.0"
 description = "Tool to run a SQL query and convert result to JSON"
 authors = [
     { name = "Francisco Perez", email = "fsistemas@gmail.com" }

--- a/sql2json/__init__.py
+++ b/sql2json/__init__.py
@@ -1,4 +1,29 @@
-__version__ = "0.1.11"
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
-from .parameter.parameter_parser import parse_parameter
+from .parameter import parse_parameter
 from .sql2json import list_connections, list_queries, run_query2json, run_query_by_name
+
+
+def _package_version() -> str:
+    try:
+        return version("sql2json")
+    except PackageNotFoundError:
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        match = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.MULTILINE)
+        if match:
+            return match.group(1)
+        raise
+
+
+__version__ = _package_version()
+
+__all__ = [
+    "__version__",
+    "parse_parameter",
+    "list_connections",
+    "list_queries",
+    "run_query_by_name",
+    "run_query2json",
+]

--- a/sql2json/parameter/__init__.py
+++ b/sql2json/parameter/__init__.py
@@ -1,8 +1,3 @@
-from .parameter_parser import is_number
-from .parameter_parser import first_day_month
-from .parameter_parser import first_day_year
-from .parameter_parser import last_day_month
-from .parameter_parser import last_day_year
-from .parameter_parser import parse_field
-from .parameter_parser import parse_formula
 from .parameter_parser import parse_parameter
+
+__all__ = ["parse_parameter"]

--- a/sql2json/parameter/parameter_parser.py
+++ b/sql2json/parameter/parameter_parser.py
@@ -12,7 +12,7 @@ DATE_FIELDS = [
 ]
 
 
-def is_number(s):
+def _is_number(s):
     try:
         float(s)
         return True
@@ -20,72 +20,72 @@ def is_number(s):
         return False
 
 
-def first_day_month(current_date):
+def _first_day_month(current_date):
     return current_date.replace(day=1)
 
 
-def first_day_year(current_date):
+def _first_day_year(current_date):
     return current_date.replace(day=1).replace(month=1)
 
 
-def last_day_year(current_date):
+def _last_day_year(current_date):
     return current_date.replace(day=31).replace(month=12)
 
 
-def last_day_month(current_date):
+def _last_day_month(current_date):
     month_last_day = calendar.monthrange(current_date.year, current_date.month)[1]
 
     return current_date.replace(day=month_last_day)
 
 
-def parse_field(field, to_add, current_date, date_format="%Y-%m-%d"):
+def _parse_field(field, to_add, current_date, date_format="%Y-%m-%d"):
     if "CURRENT_DATE" == field:
         return (current_date + timedelta(days=to_add)).strftime(date_format)
     elif "START_CURRENT_MONTH" == field:
-        return (first_day_month(current_date) + relativedelta(months=to_add)).strftime(
+        return (_first_day_month(current_date) + relativedelta(months=to_add)).strftime(
             date_format
         )
     elif "END_CURRENT_MONTH" == field:
-        return (last_day_month(current_date) + relativedelta(months=to_add)).strftime(
+        return (_last_day_month(current_date) + relativedelta(months=to_add)).strftime(
             date_format
         )
     elif "START_CURRENT_YEAR" == field:
-        return (first_day_year(current_date) + relativedelta(years=to_add)).strftime(
+        return (_first_day_year(current_date) + relativedelta(years=to_add)).strftime(
             date_format
         )
     elif "END_CURRENT_YEAR" == field:
-        return (last_day_year(current_date) + relativedelta(years=to_add)).strftime(
+        return (_last_day_year(current_date) + relativedelta(years=to_add)).strftime(
             date_format
         )
     else:
         return field
 
 
-def parse_formula(formula, current_date, date_format="%Y-%m-%d"):
+def _parse_formula(formula, current_date, date_format="%Y-%m-%d"):
     if any(ext in formula for ext in DATE_FIELDS):
         if "+" in formula:
             parts = formula.split("+")
 
-            return parse_field(
+            return _parse_field(
                 parts[0].strip(), int(parts[1]), current_date, date_format
             )
         elif "-" in formula:
             parts = formula.split("-")
-            return parse_field(
+            return _parse_field(
                 parts[0].strip(), -int(parts[1]), current_date, date_format
             )
 
-    return parse_field(formula.strip(), 0, current_date, date_format)
+    return _parse_field(formula.strip(), 0, current_date, date_format)
 
 
 def parse_parameter(param_value, current_date, format_separator="|"):
     if not param_value:
         return param_value
-    elif is_number(param_value):
+    elif _is_number(param_value):
         return param_value
     elif format_separator in str(param_value):
         field, date_format = param_value.split(format_separator)
 
-        return parse_formula(field, current_date, date_format.strip())
+        return _parse_formula(field, current_date, date_format.strip())
     else:
-        return parse_formula(param_value, current_date)
+        return _parse_formula(param_value, current_date)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,32 +1,40 @@
 import datetime
 
-from sql2json.parameter import (
-    first_day_month,
-    first_day_year,
-    is_number,
-    last_day_month,
-    last_day_year,
-    parse_field,
-    parse_formula,
-    parse_parameter,
-)
+import sql2json.parameter as parameter_api
+from sql2json.parameter import parse_parameter
+from sql2json.parameter import parameter_parser as parser
+
+
+def test_parameter_public_surface_only_exports_parse_parameter():
+    assert parameter_api.__all__ == ["parse_parameter"]
+    assert parameter_api.parse_parameter is parse_parameter
+    for private_name in (
+        "is_number",
+        "first_day_month",
+        "first_day_year",
+        "last_day_month",
+        "last_day_year",
+        "parse_field",
+        "parse_formula",
+    ):
+        assert not hasattr(parameter_api, private_name)
 
 
 def test_parse_field():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
-    assert "2019-12-30" == parse_field("2019-12-30", 0, current_date)
-    assert "name" == parse_field("name", 0, current_date)
+    assert "2019-12-30" == parser._parse_field("2019-12-30", 0, current_date)
+    assert "name" == parser._parse_field("name", 0, current_date)
 
 
 def test_parse_field_current_date_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-30" == parse_field("CURRENT_DATE", 0, current_date)
-    assert "2019-12-31" == parse_field("CURRENT_DATE", 1, current_date)
-    assert "2019-12-31 00:00:00" == parse_field(
+    assert "2019-12-30" == parser._parse_field("CURRENT_DATE", 0, current_date)
+    assert "2019-12-31" == parser._parse_field("CURRENT_DATE", 1, current_date)
+    assert "2019-12-31 00:00:00" == parser._parse_field(
         "CURRENT_DATE", 1, current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-12-31 23:59:59" == parse_field(
+    assert "2019-12-31 23:59:59" == parser._parse_field(
         "CURRENT_DATE", 1, current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -34,12 +42,12 @@ def test_parse_field_current_date_ymd():
 def test_parse_field_start_current_month_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-01" == parse_field("START_CURRENT_MONTH", 0, current_date)
-    assert "2020-01-01" == parse_field("START_CURRENT_MONTH", 1, current_date)
-    assert "2020-01-01 00:00:00" == parse_field(
+    assert "2019-12-01" == parser._parse_field("START_CURRENT_MONTH", 0, current_date)
+    assert "2020-01-01" == parser._parse_field("START_CURRENT_MONTH", 1, current_date)
+    assert "2020-01-01 00:00:00" == parser._parse_field(
         "START_CURRENT_MONTH", 1, current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2020-01-01 23:59:59" == parse_field(
+    assert "2020-01-01 23:59:59" == parser._parse_field(
         "START_CURRENT_MONTH", 1, current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -47,12 +55,12 @@ def test_parse_field_start_current_month_ymd():
 def test_parse_field_end_current_month_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-31" == parse_field("END_CURRENT_MONTH", 0, current_date)
-    assert "2020-01-31" == parse_field("END_CURRENT_MONTH", 1, current_date)
-    assert "2019-11-30 00:00:00" == parse_field(
+    assert "2019-12-31" == parser._parse_field("END_CURRENT_MONTH", 0, current_date)
+    assert "2020-01-31" == parser._parse_field("END_CURRENT_MONTH", 1, current_date)
+    assert "2019-11-30 00:00:00" == parser._parse_field(
         "END_CURRENT_MONTH", -1, current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-11-30 23:59:59" == parse_field(
+    assert "2019-11-30 23:59:59" == parser._parse_field(
         "END_CURRENT_MONTH", -1, current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -60,27 +68,27 @@ def test_parse_field_end_current_month_ymd():
 def test_parse_formula():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-30" == parse_formula("2019-12-30", current_date)
-    assert "2019-12-31" == parse_formula("2019-12-31", current_date)
-    assert "2019-12-31 00:00:00" == parse_formula(
+    assert "2019-12-30" == parser._parse_formula("2019-12-30", current_date)
+    assert "2019-12-31" == parser._parse_formula("2019-12-31", current_date)
+    assert "2019-12-31 00:00:00" == parser._parse_formula(
         "2019-12-31 00:00:00", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-12-31 23:59:59" == parse_formula(
+    assert "2019-12-31 23:59:59" == parser._parse_formula(
         "2019-12-31 23:59:59", current_date, date_format="%Y-%m-%d 23:59:59"
     )
-    assert "field1" == parse_formula("field1", current_date)
-    assert "55" == parse_formula("55", current_date)
+    assert "field1" == parser._parse_formula("field1", current_date)
+    assert "55" == parser._parse_formula("55", current_date)
 
 
 def test_parse_formula_current_date_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-30" == parse_formula("CURRENT_DATE", current_date)
-    assert "2019-12-31" == parse_formula("CURRENT_DATE+1", current_date)
-    assert "2019-12-31 00:00:00" == parse_formula(
+    assert "2019-12-30" == parser._parse_formula("CURRENT_DATE", current_date)
+    assert "2019-12-31" == parser._parse_formula("CURRENT_DATE+1", current_date)
+    assert "2019-12-31 00:00:00" == parser._parse_formula(
         "CURRENT_DATE + 1", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-12-31 23:59:59" == parse_formula(
+    assert "2019-12-31 23:59:59" == parser._parse_formula(
         "CURRENT_DATE + 1", current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -88,15 +96,15 @@ def test_parse_formula_current_date_ymd():
 def test_parse_formula_start_current_month_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-01" == parse_formula("START_CURRENT_MONTH", current_date)
-    assert "2020-01-01" == parse_formula("START_CURRENT_MONTH+1", current_date)
-    assert "2020-01-01 00:00:00" == parse_formula(
+    assert "2019-12-01" == parser._parse_formula("START_CURRENT_MONTH", current_date)
+    assert "2020-01-01" == parser._parse_formula("START_CURRENT_MONTH+1", current_date)
+    assert "2020-01-01 00:00:00" == parser._parse_formula(
         "START_CURRENT_MONTH+1", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2020/01/01 00:00:00" == parse_formula(
+    assert "2020/01/01 00:00:00" == parser._parse_formula(
         "START_CURRENT_MONTH+1", current_date, date_format="%Y/%m/%d 00:00:00"
     )
-    assert "2020-01-01 23:59:59" == parse_formula(
+    assert "2020-01-01 23:59:59" == parser._parse_formula(
         "START_CURRENT_MONTH + 1", current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -104,12 +112,12 @@ def test_parse_formula_start_current_month_ymd():
 def test_parse_formula_end_current_month_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
-    assert "2019-12-31" == parse_formula("END_CURRENT_MONTH", current_date)
-    assert "2020-01-31" == parse_formula("END_CURRENT_MONTH+1", current_date)
-    assert "2019-11-30 00:00:00" == parse_formula(
+    assert "2019-12-31" == parser._parse_formula("END_CURRENT_MONTH", current_date)
+    assert "2020-01-31" == parser._parse_formula("END_CURRENT_MONTH+1", current_date)
+    assert "2019-11-30 00:00:00" == parser._parse_formula(
         "END_CURRENT_MONTH-1", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-11-30 23:59:59" == parse_formula(
+    assert "2019-11-30 23:59:59" == parser._parse_formula(
         "END_CURRENT_MONTH - 1 ", current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -118,11 +126,11 @@ def test_parse_parameter():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
     assert "2019-12-30" == parse_parameter("2019-12-30", current_date)
-    assert "2019-12-31" == parse_formula("2019-12-31", current_date)
-    assert "2019-12-31 00:00:00" == parse_formula(
+    assert "2019-12-31" == parser._parse_formula("2019-12-31", current_date)
+    assert "2019-12-31 00:00:00" == parser._parse_formula(
         "2019-12-31 00:00:00", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-12-31 23:59:59" == parse_formula(
+    assert "2019-12-31 23:59:59" == parser._parse_formula(
         "2019-12-31 23:59:59", current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -137,11 +145,11 @@ def test_parse_parameter_current_date_ymd():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
 
     assert "2019-12-30" == parse_parameter("CURRENT_DATE", current_date)
-    assert "2019-12-31" == parse_formula("CURRENT_DATE+1", current_date)
-    assert "2019-12-31 00:00:00" == parse_formula(
+    assert "2019-12-31" == parser._parse_formula("CURRENT_DATE+1", current_date)
+    assert "2019-12-31 00:00:00" == parser._parse_formula(
         "CURRENT_DATE + 1", current_date, date_format="%Y-%m-%d 00:00:00"
     )
-    assert "2019-12-31 23:59:59" == parse_formula(
+    assert "2019-12-31 23:59:59" == parser._parse_formula(
         "CURRENT_DATE + 1", current_date, date_format="%Y-%m-%d 23:59:59"
     )
 
@@ -213,34 +221,34 @@ def test_parse_parameter_end_current_year_ymd():
 
 
 def test_is_number():
-    assert is_number("123")
-    assert not is_number("123A")
-    assert not is_number("B123")
+    assert parser._is_number("123")
+    assert not parser._is_number("123A")
+    assert not parser._is_number("B123")
 
 
 def test_first_day_month():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
     assert datetime.datetime.strptime(
         "2019-12-01", "%Y-%m-%d"
-    ).date() == first_day_month(current_date)
+    ).date() == parser._first_day_month(current_date)
 
 
 def test_last_day_month():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
     assert datetime.datetime.strptime(
         "2019-12-31", "%Y-%m-%d"
-    ).date() == last_day_month(current_date)
+    ).date() == parser._last_day_month(current_date)
 
 
 def test_first_day_year():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
     assert datetime.datetime.strptime(
         "2019-01-01", "%Y-%m-%d"
-    ).date() == first_day_year(current_date)
+    ).date() == parser._first_day_year(current_date)
 
 
 def test_last_day_year():
     current_date = datetime.datetime.strptime("2019-12-30", "%Y-%m-%d").date()
-    assert datetime.datetime.strptime("2019-12-31", "%Y-%m-%d").date() == last_day_year(
-        current_date
-    )
+    assert datetime.datetime.strptime(
+        "2019-12-31", "%Y-%m-%d"
+    ).date() == parser._last_day_year(current_date)

--- a/tests/test_sql2json.py
+++ b/tests/test_sql2json.py
@@ -1,13 +1,26 @@
 import datetime
+from importlib.metadata import version
 
 import pytest
+import sql2json
 
 from sql2json import __version__, run_query_by_name
 from sql2json.sql2json import _current_date
 
 
-def test_version():
-    assert __version__ == "0.1.11"
+def test_version_matches_package_metadata():
+    assert __version__ == version("sql2json")
+
+
+def test_top_level_public_surface():
+    assert sql2json.__all__ == [
+        "__version__",
+        "parse_parameter",
+        "list_connections",
+        "list_queries",
+        "run_query_by_name",
+        "run_query2json",
+    ]
 
 
 def test_run_query_by_name_empty_param():

--- a/uv.lock
+++ b/uv.lock
@@ -614,7 +614,7 @@ wheels = [
 
 [[package]]
 name = "sql2json"
-version = "0.1.11"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary

Makes the public/internal API boundary of `sql2json` explicit before future refactors (it is a public GitHub/PyPI package). Closes FRA-165.

- Define `__all__` in `sql2json/__init__.py` and `sql2json/parameter/__init__.py` to declare the supported surface.
- Privatize the 7 trivial date helpers (`_is_number`, `_first_day_month`, `_first_day_year`, `_last_day_month`, `_last_day_year`, `_parse_field`, `_parse_formula`); `parse_parameter` stays public.
- Single-source `__version__` via `importlib.metadata.version("sql2json")`, with a pyproject fallback when not installed.
- Bump version to `0.2.0` (minor, per `0.x` SemVer — no deprecation cycle required) and update CHANGELOG with a migration note.
- Add runnable Python API examples under `examples/python_api/` plus README docs distinguishing the public Python API and the CLI compatibility contract from internal helpers.

## Versioning

Pre-1.0 (`0.x`), so tightening the boundary ships as a `0.2.0` minor bump with no formal deprecation cycle. Migration: anyone importing the date helpers from `sql2json.parameter` should switch to the public `parse_parameter`.

## Testing

- `uv run pytest` — 68 passed
- `uv run flake8` — clean
- All 8 `examples/python_api/*.py` scripts run and produce correct output