### PR TITLE
test: expand coverage for CLI outputs and result transformations (FRA-166)

### DIFF
--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -1,0 +1,320 @@
+"""
+Tests for the CLI output/serialization helpers in sql2json.__main__ and the
+end-to-end --output file-writing path.
+
+Unit tests exercise the helpers directly with temp files; the CLI tests run
+sql2json as a subprocess. Nothing is written to the repo root.
+"""
+
+import csv
+import datetime
+import json
+import os
+import subprocess
+import sys
+from decimal import Decimal
+
+import pytest
+
+from sql2json.__main__ import (
+    handle_run_query2json,
+    json_default,
+    json_dumps,
+    parse_filename,
+    save_csv,
+    save_json,
+)
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+FIXED_DATE = datetime.date(2019, 12, 30)
+
+
+def run_cli(*args, extra_env=None):
+    env = {**os.environ, "PYTHONPATH": PROJECT_DIR}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "sql2json"] + list(args),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestParseFilename:
+    def test_plain_name_unchanged(self):
+        assert parse_filename("report.json", FIXED_DATE) == "report.json"
+
+    def test_current_date_placeholder_is_resolved(self):
+        assert (
+            parse_filename("report_{CURRENT_DATE}.json", FIXED_DATE)
+            == "report_2019-12-30.json"
+        )
+
+    def test_multiple_placeholders(self):
+        assert (
+            parse_filename("{CURRENT_DATE}_to_{CURRENT_DATE}.csv", FIXED_DATE)
+            == "2019-12-30_to_2019-12-30.csv"
+        )
+
+
+class TestJsonDefault:
+    def test_decimal_becomes_float(self):
+        assert json_default(Decimal("5000.00")) == 5000.0
+
+    def test_unsupported_type_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            json_default({1, 2, 3})
+
+    def test_json_dumps_serializes_decimal_rows(self):
+        assert json_dumps([{"amount": Decimal("1.50")}]) == '[{"amount": 1.5}]'
+
+
+class TestSaveJson:
+    def test_appends_json_extension(self, tmp_path):
+        target = tmp_path / "report"
+        save_json([{"a": 1}], str(target))
+        written = tmp_path / "report.json"
+        assert written.exists()
+        assert json.loads(written.read_text()) == [{"a": 1}]
+
+    def test_keeps_existing_json_extension(self, tmp_path):
+        target = tmp_path / "report.json"
+        save_json([{"a": 1}], str(target))
+        assert target.exists()
+        assert not (tmp_path / "report.json.json").exists()
+
+    def test_serializes_decimal(self, tmp_path):
+        target = tmp_path / "money.json"
+        save_json([{"amount": Decimal("9.99")}], str(target))
+        assert json.loads(target.read_text()) == [{"amount": 9.99}]
+
+
+class TestSaveCsv:
+    def test_list_of_dicts_writes_header_and_rows(self, tmp_path):
+        target = tmp_path / "out"
+        save_csv([{"a": 1, "b": 2}, {"a": 3, "b": 4}], str(target), "csv", "")
+        written = tmp_path / "out.csv"
+        assert written.exists()
+        rows = list(csv.DictReader(written.open()))
+        assert rows == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+
+    def test_scalar_string_uses_default_key(self, tmp_path):
+        target = tmp_path / "scalar"
+        save_csv("hello", str(target), "csv", "")
+        rows = list(csv.DictReader((tmp_path / "scalar.csv").open()))
+        assert rows == [{"key": "hello"}]
+
+    def test_scalar_string_uses_provided_key(self, tmp_path):
+        target = tmp_path / "scalar"
+        save_csv("hello", str(target), "csv", "label")
+        rows = list(csv.DictReader((tmp_path / "scalar.csv").open()))
+        assert rows == [{"label": "hello"}]
+
+    def test_single_dict_writes_one_row(self, tmp_path):
+        target = tmp_path / "single"
+        save_csv({"a": 1, "b": 2}, str(target), "csv", "")
+        rows = list(csv.DictReader((tmp_path / "single.csv").open()))
+        assert rows == [{"a": "1", "b": "2"}]
+
+    def test_excel_dialect_uses_xls_extension(self, tmp_path):
+        target = tmp_path / "book"
+        save_csv([{"a": 1}], str(target), "excel", "")
+        assert (tmp_path / "book.xls").exists()
+
+    def test_empty_rows_raises(self, tmp_path):
+        # Degenerate input: an empty result set has no columns to write.
+        target = tmp_path / "empty"
+        with pytest.raises(Exception):
+            save_csv([], str(target), "csv", "")
+
+
+class TestCliOutput:
+    def test_json_output_creates_file(self, tmp_path):
+        target = tmp_path / "result"
+        result = run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a, 2 AS b",
+            "--output",
+            str(target),
+        )
+        assert result.returncode == 0
+        written = tmp_path / "result.json"
+        assert written.exists()
+        assert json.loads(written.read_text()) == [{"a": 1, "b": 2}]
+
+    def test_json_output_keeps_stdout_empty(self, tmp_path):
+        target = tmp_path / "result"
+        result = run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a",
+            "--output",
+            str(target),
+        )
+        assert result.stdout == ""
+
+    def test_csv_output_creates_csv_file(self, tmp_path):
+        target = tmp_path / "result"
+        result = run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a, 2 AS b",
+            "--format",
+            "csv",
+            "--output",
+            str(target),
+        )
+        assert result.returncode == 0
+        written = tmp_path / "result.csv"
+        assert written.exists()
+        rows = list(csv.DictReader(written.open()))
+        assert rows == [{"a": "1", "b": "2"}]
+
+    @pytest.mark.xfail(
+        reason="FRA-172: --format csv also writes a stray .json file",
+        strict=True,
+    )
+    def test_csv_output_does_not_create_json(self, tmp_path):
+        target = tmp_path / "result"
+        run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a, 2 AS b",
+            "--format",
+            "csv",
+            "--output",
+            str(target),
+        )
+        # Desired behavior: csv output should not also produce a .json file.
+        # Currently fails (xfail) until FRA-172 is fixed; will xpass after.
+        assert not (tmp_path / "result.json").exists()
+
+    def test_excel_output_creates_xls_file(self, tmp_path):
+        target = tmp_path / "result"
+        result = run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a, 2 AS b",
+            "--format",
+            "excel",
+            "--output",
+            str(target),
+        )
+        assert result.returncode == 0
+        assert (tmp_path / "result.xls").exists()
+
+    def test_output_filename_resolves_date_placeholder(self, tmp_path):
+        target = tmp_path / "report_{CURRENT_DATE}"
+        result = run_cli(
+            "--name",
+            "sqlite:///:memory:",
+            "--query",
+            "SELECT 1 AS a",
+            "--output",
+            str(target),
+            "--timezone",
+            "UTC",
+        )
+        assert result.returncode == 0
+        produced = list(tmp_path.glob("report_*.json"))
+        assert len(produced) == 1
+
+
+CONFIG = {
+    "conections": {"default": "sqlite:///:memory:", "reporting": "sqlite:///:memory:"},
+    "queries": {"default": "SELECT 1 AS a, 2 AS b", "sales": "SELECT 42 AS total"},
+}
+
+
+def _write_config(tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps(CONFIG))
+    return str(cfg)
+
+
+class TestHandleRunQuery2Json:
+    """In-process tests for the CLI entry point so its branches are covered."""
+
+    def test_prints_json_to_stdout(self, capsys, tmp_path):
+        handle_run_query2json(query="SELECT 7 AS n", config=_write_config(tmp_path))
+        out = json.loads(capsys.readouterr().out)
+        assert out == [{"n": 7}]
+
+    def test_list_connections_branch(self, capsys, tmp_path):
+        handle_run_query2json(list_connections=True, config=_write_config(tmp_path))
+        names = json.loads(capsys.readouterr().out)
+        assert sorted(names) == ["default", "reporting"]
+
+    def test_list_queries_branch(self, capsys, tmp_path):
+        handle_run_query2json(list_queries=True, config=_write_config(tmp_path))
+        names = json.loads(capsys.readouterr().out)
+        assert sorted(names) == ["default", "sales"]
+
+    def test_key_first_prints_scalar(self, capsys, tmp_path):
+        handle_run_query2json(
+            query="SELECT 42 AS total",
+            key="total",
+            first=True,
+            config=_write_config(tmp_path),
+        )
+        assert capsys.readouterr().out.strip() == "42"
+
+    def test_key_value_first_prints_json_pair(self, capsys, tmp_path):
+        handle_run_query2json(
+            query="SELECT 'a' AS k, 1 AS v",
+            key="k",
+            value="v",
+            first=True,
+            config=_write_config(tmp_path),
+        )
+        assert json.loads(capsys.readouterr().out) == {"a": 1}
+
+    def test_json_output_to_file(self, tmp_path):
+        target = tmp_path / "result"
+        handle_run_query2json(
+            query="SELECT 1 AS a",
+            output=str(target),
+            config=_write_config(tmp_path),
+        )
+        assert json.loads((tmp_path / "result.json").read_text()) == [{"a": 1}]
+
+    def test_csv_output_to_file(self, tmp_path):
+        target = tmp_path / "result"
+        handle_run_query2json(
+            query="SELECT 1 AS a, 2 AS b",
+            format="csv",
+            output=str(target),
+            config=_write_config(tmp_path),
+        )
+        rows = list(csv.DictReader((tmp_path / "result.csv").open()))
+        assert rows == [{"a": "1", "b": "2"}]
+
+    def test_excel_output_to_file(self, tmp_path):
+        target = tmp_path / "book"
+        handle_run_query2json(
+            query="SELECT 1 AS a",
+            format="excel",
+            output=str(target),
+            config=_write_config(tmp_path),
+        )
+        assert (tmp_path / "book.xls").exists()
+
+    def test_error_path_exits_and_writes_json_stderr(self, capsys, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            handle_run_query2json(
+                query="SELECT * FROM nonexistent_table",
+                config=_write_config(tmp_path),
+            )
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        error = json.loads(captured.err)
+        assert "error" in error and "type" in error

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for run_query2json output transformations and the helpers it uses.
+
+These run in-process against an in-memory SQLite database (no config file
+needed: an explicit connection string and inline SQL are passed straight
+through). They cover first/key/value/wrapper/jsonkeys shapes, SQL-file loading,
+and the small result-shaping helpers in sql2json.sql2json.
+"""
+
+import json
+
+import pytest
+
+from sql2json import run_query2json
+from sql2json.sql2json import (
+    get_for_key_or_first_map_value,
+    load_query_from_file,
+    parse_json_columns,
+)
+
+MEMORY = "sqlite:///:memory:"
+TWO_ROWS = (
+    "SELECT 'January' AS month, 5000 AS sales " "UNION ALL SELECT 'February', 3000"
+)
+NO_ROWS = "SELECT 'x' AS month, 1 AS sales WHERE 1 = 0"
+
+
+class TestDefaultShape:
+    def test_returns_list_of_rows(self):
+        rows = run_query2json(name=MEMORY, query=TWO_ROWS)
+        assert rows == [
+            {"month": "January", "sales": 5000},
+            {"month": "February", "sales": 3000},
+        ]
+
+
+class TestFirst:
+    def test_first_returns_single_row(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, first=True)
+        assert result == {"month": "January", "sales": 5000}
+
+    def test_first_with_key_extracts_scalar(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, first=True, key="sales")
+        assert result == 5000
+
+    def test_first_with_key_and_value_makes_single_pair(self):
+        result = run_query2json(
+            name=MEMORY, query=TWO_ROWS, first=True, key="month", value="sales"
+        )
+        assert result == {"January": 5000}
+
+    def test_first_on_empty_with_key_returns_empty_string(self):
+        result = run_query2json(name=MEMORY, query=NO_ROWS, first=True, key="sales")
+        assert result == ""
+
+    def test_first_on_empty_without_key_returns_empty_dict(self):
+        result = run_query2json(name=MEMORY, query=NO_ROWS, first=True)
+        assert result == {}
+
+
+class TestKeyValue:
+    def test_key_only_extracts_column_values(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, key="month")
+        assert result == ["January", "February"]
+
+    def test_key_and_value_makes_pairs(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, key="month", value="sales")
+        assert result == [{"January": 5000}, {"February": 3000}]
+
+
+class TestWrapper:
+    def test_wrapper_wraps_list_in_data(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper=True)
+        assert result == {
+            "data": [
+                {"month": "January", "sales": 5000},
+                {"month": "February", "sales": 3000},
+            ]
+        }
+
+    def test_wrapper_with_first(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper=True, first=True)
+        assert result == {"data": {"month": "January", "sales": 5000}}
+
+
+class TestJsonKeys:
+    def test_string_column_is_parsed_into_object(self):
+        query = 'SELECT \'{"x": 1, "y": [2, 3]}\' AS payload'
+        result = run_query2json(name=MEMORY, query=query, jsonkeys="payload")
+        assert result == [{"payload": {"x": 1, "y": [2, 3]}}]
+
+    def test_unlisted_columns_are_left_untouched(self):
+        query = "SELECT '{\"x\": 1}' AS payload, 'plain' AS note"
+        result = run_query2json(name=MEMORY, query=query, jsonkeys="payload")
+        assert result == [{"payload": {"x": 1}, "note": "plain"}]
+
+    def test_malformed_json_raises(self):
+        # Documents current behavior: invalid JSON in a jsonkeys column surfaces
+        # as a normal exception from the library API.
+        query = "SELECT 'not valid json' AS payload"
+        with pytest.raises(json.JSONDecodeError):
+            run_query2json(name=MEMORY, query=query, jsonkeys="payload")
+
+
+class TestSqlFile:
+    def test_query_loaded_from_at_path(self, tmp_path):
+        sql_file = tmp_path / "query.sql"
+        sql_file.write_text("SELECT :answer AS answer")
+        result = run_query2json(name=MEMORY, query=f"@{sql_file}", answer=123)
+        assert result == [{"answer": 123}]
+
+
+class TestLoadQueryFromFile:
+    def test_reads_plain_path(self, tmp_path):
+        sql_file = tmp_path / "q.sql"
+        sql_file.write_text("SELECT 1")
+        assert load_query_from_file(str(sql_file)) == "SELECT 1"
+
+    def test_strips_leading_at(self, tmp_path):
+        sql_file = tmp_path / "q.sql"
+        sql_file.write_text("SELECT 2")
+        assert load_query_from_file(f"@{sql_file}") == "SELECT 2"
+
+
+class TestParseJsonColumns:
+    def test_no_jsonkeys_returns_input_unchanged(self):
+        row = {"a": '{"x": 1}'}
+        assert parse_json_columns(row, "") == row
+
+    def test_tuple_jsonkeys_supported(self):
+        row = {"payload": '{"x": 1}'}
+        assert parse_json_columns(row, ("payload",)) == {"payload": {"x": 1}}
+
+    def test_non_str_non_tuple_jsonkeys_returns_input_unchanged(self):
+        # jsonkeys of an unexpected type yields no keys to parse.
+        row = {"payload": '{"x": 1}'}
+        assert parse_json_columns(row, None) == row
+
+
+class TestGetForKeyOrFirstMapValue:
+    def test_returns_value_for_present_key(self):
+        assert get_for_key_or_first_map_value({"a": 1, "b": 2}, "b") == 2
+
+    def test_returns_first_value_when_key_absent(self):
+        assert get_for_key_or_first_map_value({"a": 1, "b": 2}, "missing") == 1
+
+    def test_returns_empty_string_for_empty_dict(self):
+        assert get_for_key_or_first_map_value({}, "anything") == ""


### PR DESCRIPTION
## Summary

Expands high-value test coverage for the CLI output paths and result transformations, raising total coverage from **57% to 97%** (`sql2json.py` 100%, `__main__.py` 99%).

### New test files
- **`tests/test_transformations.py`** — in-process tests for `run_query2json` output shapes (first / key / value / wrapper / jsonkeys), `@`-prefixed SQL-file loading, and the result-shaping helpers (`parse_json_columns`, `get_for_key_or_first_map_value`, `load_query_from_file`). Runs against in-memory SQLite — no config file or external DB needed.
- **`tests/test_output_files.py`** — tests for the `__main__` serialization helpers (`parse_filename`, `json_default`, `json_dumps`, `save_json`, `save_csv`) plus the CLI `--output` path, exercised both as a subprocess and in-process via `handle_run_query2json` (so the entry-point branches register coverage).

### Results
- `119 passed, 1 xfailed`
- `flake8` clean, `black --check` clean

### Note
While testing the output paths I found that `--format csv --output` also writes a stray `.json` file (an `if`/`elif` bug in `handle_run_query2json`). Per scope, this PR is **tests only** — the bug is filed as **FRA-172** and captured here as a `strict=True` xfail tripwire that will flip to xpass once FRA-172 is fixed.

Closes FRA-166.