### PR TITLE
fix: --format csv no longer writes a stray .json file (FRA-172)

### DIFF
--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -124,7 +124,7 @@ def handle_run_query2json(
         if output:
             if "csv" == format:
                 save_csv(result, output, "csv", key, timezone=timezone)
-            if "excel" == format:
+            elif "excel" == format:
                 save_csv(result, output, "excel", key, timezone=timezone)
             else:
                 save_json(result, output, timezone=timezone)

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -176,10 +176,6 @@ class TestCliOutput:
         rows = list(csv.DictReader(written.open()))
         assert rows == [{"a": "1", "b": "2"}]
 
-    @pytest.mark.xfail(
-        reason="FRA-172: --format csv also writes a stray .json file",
-        strict=True,
-    )
     def test_csv_output_does_not_create_json(self, tmp_path):
         target = tmp_path / "result"
         run_cli(
@@ -192,8 +188,7 @@ class TestCliOutput:
             "--output",
             str(target),
         )
-        # Desired behavior: csv output should not also produce a .json file.
-        # Currently fails (xfail) until FRA-172 is fixed; will xpass after.
+        # Regression guard for FRA-172: csv output must not also produce a .json.
         assert not (tmp_path / "result.json").exists()
 
     def test_excel_output_creates_xls_file(self, tmp_path):


### PR DESCRIPTION
## Summary

`--format csv --output <path>` was writing **both** `<path>.csv` and an unintended `<path>.json`. Only the CSV file should be produced.

## Root cause

`handle_run_query2json` used a standalone `if` for the csv branch and a separate `if/else` for excel/json. When `format == "csv"`, the `excel` test was false, so the `else` ran and additionally wrote JSON.

## Fix

Chain the format selection with `elif` so exactly one writer runs:

```python
if "csv" == format:
    save_csv(result, output, "csv", key, timezone=timezone)
elif "excel" == format:
    save_csv(result, output, "excel", key, timezone=timezone)
else:
    save_json(result, output, timezone=timezone)
```

Excel and default json paths are unaffected (each already wrote a single file).

## Tests

Un-marks the FRA-166 xfail tripwire (`test_csv_output_does_not_create_json`) so it now runs as a real regression guard. Full suite: `120 passed`, flake8 clean.

## Out of scope

`black` flags some pre-existing formatting drift in `__main__.py` (trailing comma on `**kwargs`, wrapping a long call). That's unrelated to this bug and is tracked under FRA-168 (CI/formatting gates), so it's intentionally left out to keep this fix surgical.

Closes FRA-172.