### PR TITLE
test: add PostgreSQL and MySQL integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  unit:
+    name: Unit tests (fast, no Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync
+      - name: Lint
+        run: uv run flake8
+      - name: Run unit tests
+        run: uv run pytest
+
+  integration:
+    name: Database integration (PostgreSQL + MySQL)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      # Provisions the docker-compose postgres/mysql services (seeded from
+      # docker/initdb.sql), runs the integration suite against them, and tears
+      # them down. Demo credentials are local/demo-only and safe in a public repo.
+      - name: Run database integration tests
+        run: ./scripts/test-integration.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > date-variable resolution.
 
 ### Added
+- Real-database integration test suite (`tests/integration/`) covering the PostgreSQL and MySQL demo paths: named connection lookup, named query lookup, bind parameters, Decimal values, and JSON serialization. Tests are marked `integration` and deselected by default, so `uv run pytest` stays fast and Docker-free. Run them with `./scripts/test-integration.sh` (provisions the `docker-compose.yml` services, runs the suite, tears down) or `uv run --extra integration pytest -m integration tests/integration` against already-running services. Each test skips cleanly when its database is unreachable. A `.github/workflows/ci.yml` `integration` job provisions the services in CI.
 - Explicit `__all__` exports for the supported top-level Python API and `sql2json.parameter` surface.
 - Python API documentation and runnable examples under `examples/python_api`.
 - `--timezone` flag: accepts an IANA timezone name (e.g. `--timezone America/New_York`, `--timezone UTC`) and uses it when resolving `CURRENT_DATE`, `START_CURRENT_MONTH`, and all other date variables. Defaults to local system timezone (backward-compatible). An invalid timezone name produces a structured JSON error on stderr and a non-zero exit code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Install dependencies
 uv sync
 
-# Run all tests
+# Run all tests (fast, in-memory SQLite — no Docker)
 uv run pytest
 
 # Run a single test
 uv run pytest tests/test_parameter.py::test_parse_parameter
+
+# Run the real-database integration suite (PostgreSQL + MySQL via docker compose)
+# Provisions services, runs the `integration`-marked tests, then tears down.
+./scripts/test-integration.sh
 
 # Lint
 uv run flake8
@@ -73,6 +77,11 @@ Query values prefixed with `@` are treated as file paths to `.sql` files.
 | `--format` | `json` (default), `csv`, or `excel` |
 | `--output` | Save to file instead of printing; filename supports `{CURRENT_DATE}` etc. |
 | `--timezone` | IANA timezone name for resolving date variables (e.g. `UTC`, `America/New_York`). Defaults to local system timezone. |
+
+### Tests
+
+- **Unit tests** (`uv run pytest`) use the in-memory SQLite fallback — fast, no Docker, no external DB.
+- **Integration tests** (`tests/integration/`, marked `integration`, deselected by default via `addopts` in `pyproject.toml`) run against the real PostgreSQL and MySQL `docker-compose.yml` services. The `database` fixture in `tests/integration/conftest.py` builds a temp config that maps a connection name to a `127.0.0.1` URL (overridable with `SQL2JSON_TEST_PG_URL` / `SQL2JSON_TEST_MYSQL_URL`) and reuses the named queries from `docker/config.json`. Tests `pytest.skip` cleanly when a database is unreachable or its driver (`psycopg2-binary` / `pymysql`, the `integration` extra) is missing. Run with `./scripts/test-integration.sh`.
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,37 @@ docker compose down
 
 The demo config lives in `docker/config.json` and the seed table in `docker/initdb.sql`.
 
+### Real database verification
+
+The fast unit suite runs against in-memory SQLite and needs no Docker:
+
+```bash
+uv run pytest
+```
+
+A separate, opt-in integration suite verifies the documented demo paths (named
+connection lookup, named query lookup, bind parameters, Decimal values, and JSON
+serialization) against the real PostgreSQL and MySQL services. The one command
+below provisions the `docker-compose.yml` services, runs the suite, and tears
+them down:
+
+```bash
+./scripts/test-integration.sh
+```
+
+The integration tests are marked `integration` and deselected by default, so
+`uv run pytest` stays Docker-free. To run them against already-running services
+(or a different host/port via `SQL2JSON_TEST_PG_URL` / `SQL2JSON_TEST_MYSQL_URL`):
+
+```bash
+docker compose up -d postgres mysql
+uv run --extra integration pytest -m integration tests/integration
+```
+
+Each test **skips cleanly** when its database is unreachable, so a machine
+without Docker never sees failures. In CI, the `integration` job in
+`.github/workflows/ci.yml` provisions the services and runs the same suite.
+
 ## Quick start
 
 **1. Create the config file:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,18 @@ dev = [
     "black>=19.10b0",
     "pre-commit>=1.10",
 ]
+integration = [
+    "psycopg2-binary>=2.9",
+    "pymysql>=1.1",
+]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "integration: real-database tests requiring docker-compose services (deselected by default; run with -m integration)",
+]
+addopts = "-m 'not integration'"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Real-database integration verification for sql2json.
+#
+# Provisions the docker-compose PostgreSQL and MySQL services, waits for them to
+# become healthy, runs the `integration`-marked pytest suite against them, then
+# tears the services down. This is the "clear command for real DB verification"
+# that is separate from the fast, Docker-free unit suite (`uv run pytest`).
+#
+# Usage:
+#   ./scripts/test-integration.sh            # provision, test, tear down
+#   KEEP=1 ./scripts/test-integration.sh     # leave services running afterwards
+#
+# Requires Docker (or a `docker compose` shim such as podman-compose) and uv.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+services=(postgres mysql)
+
+teardown() {
+  if [[ "${KEEP:-0}" == "1" ]]; then
+    echo ">> KEEP=1 set; leaving services running. Tear down with: docker compose down"
+    return
+  fi
+  echo ">> Tearing down docker compose services..."
+  docker compose down --volumes --remove-orphans || true
+}
+trap teardown EXIT
+
+echo ">> Starting services: ${services[*]}"
+# `--wait` blocks until healthchecks pass (docker compose v2). Fall back to a
+# manual readiness poll for shims that don't support it.
+if ! docker compose up -d --wait "${services[@]}" 2>/dev/null; then
+  echo ">> '--wait' unsupported; starting without it and polling for readiness."
+  docker compose up -d "${services[@]}"
+
+  echo ">> Waiting for PostgreSQL..."
+  for _ in $(seq 1 30); do
+    if docker compose exec -T postgres pg_isready -U demo >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+  done
+
+  echo ">> Waiting for MySQL..."
+  for _ in $(seq 1 30); do
+    if docker compose exec -T mysql mysqladmin ping -h 127.0.0.1 --silent >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+  done
+fi
+
+echo ">> Running integration tests..."
+uv run --extra integration pytest -m integration tests/integration "$@"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,85 @@
+"""Fixtures for real-database integration tests (PostgreSQL and MySQL).
+
+These tests run against the services defined in `docker-compose.yml`. They are
+marked `integration` and deselected by default (see `addopts` in pyproject.toml),
+so the fast unit suite stays Docker-free. Run them with:
+
+    ./scripts/test-integration.sh                       # provisions + tears down
+    uv run --extra integration pytest -m integration    # against running services
+
+Each test skips cleanly (it never fails) when the target database is unreachable
+or its driver is missing, so a machine without Docker does not break the build.
+Override the connection URLs with SQL2JSON_TEST_PG_URL / SQL2JSON_TEST_MYSQL_URL.
+"""
+
+import json
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text
+
+PROJECT_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+DOCKER_CONFIG_PATH = os.path.join(PROJECT_DIR, "docker", "config.json")
+
+# (connection name, env var overriding the URL, default host-side localhost URL).
+# The docker-compose ports bind to 127.0.0.1, so host-run tests use localhost
+# rather than the in-network hostnames (postgres / mysql) in docker/config.json.
+DATABASES = [
+    (
+        "pg",
+        "SQL2JSON_TEST_PG_URL",
+        "postgresql+psycopg2://demo:demo@127.0.0.1:5432/demo",
+    ),
+    (
+        "mysql",
+        "SQL2JSON_TEST_MYSQL_URL",
+        "mysql+pymysql://demo:demo@127.0.0.1:3306/demo",
+    ),
+]
+
+
+def _load_docker_queries():
+    """The named queries the README documents (version / sales / sales_by_month)."""
+    with open(DOCKER_CONFIG_PATH) as f:
+        return json.load(f)["queries"]
+
+
+def _require_reachable(url):
+    """Skip (not fail) when the driver is missing or the database is down."""
+    try:
+        engine = create_engine(url)
+        with engine.connect() as con:
+            con.execute(text("SELECT 1"))
+    except Exception as exc:  # ModuleNotFoundError, OperationalError, ...
+        pytest.skip(
+            f"database not reachable at {url!r}: {type(exc).__name__}: {exc}. "
+            "Start services with ./scripts/test-integration.sh or "
+            "`docker compose up -d postgres mysql`."
+        )
+
+
+@pytest.fixture(params=[name for name, _, _ in DATABASES])
+def database(request, tmp_path):
+    """Yield a reachable demo database, exercising named connection lookup.
+
+    Builds a temp config.json that maps the connection name to a localhost URL
+    and reuses the demo queries from docker/config.json, so tests go through the
+    same named-connection / named-query resolution as a real CLI invocation.
+    """
+    name = request.param
+    _, env_var, default_url = next(d for d in DATABASES if d[0] == name)
+    url = os.environ.get(env_var, default_url)
+
+    _require_reachable(url)
+
+    config = {
+        "connections": {name: url},
+        "queries": _load_docker_queries(),
+    }
+    config_path = tmp_path / "integration-config.json"
+    config_path.write_text(json.dumps(config))
+
+    return {"name": name, "url": url, "config": str(config_path)}

--- a/tests/integration/test_databases.py
+++ b/tests/integration/test_databases.py
@@ -1,0 +1,83 @@
+"""Real-database integration tests for the documented demo paths.
+
+Covers, for both PostgreSQL and MySQL: named connection lookup, named query
+lookup, bind parameters, numeric/Decimal values, and end-to-end JSON
+serialization through the CLI. Marked `integration` (deselected by default);
+see tests/integration/conftest.py for provisioning and clean-skip behavior.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from decimal import Decimal
+
+import pytest
+
+from sql2json import run_query2json
+from sql2json.__main__ import json_dumps
+
+pytestmark = pytest.mark.integration
+
+PROJECT_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+
+def run_cli(*args):
+    env = {**os.environ, "PYTHONPATH": PROJECT_DIR}
+    return subprocess.run(
+        [sys.executable, "-m", "sql2json"] + list(args),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_named_connection_and_query_version(database):
+    """Named connection + named `version` query returns one row of server text."""
+    rows = run_query2json(database["name"], "version", config=database["config"])
+    assert len(rows) == 1
+    assert isinstance(rows[0]["version"], str)
+    assert rows[0]["version"]
+
+
+def test_named_query_sales_returns_seed_rows(database):
+    """Named `sales` query returns the three seed rows with exact Decimal amounts."""
+    rows = run_query2json(database["name"], "sales", config=database["config"])
+    by_month = {r["month"]: r["amount"] for r in rows}
+    assert len(rows) == 3
+    assert by_month["January"] == Decimal("5000.00")
+    assert by_month["February"] == Decimal("3200.50")
+    assert by_month["March"] == Decimal("7100.75")
+
+
+def test_numeric_values_are_decimal(database):
+    """DECIMAL columns come back as Decimal from both drivers."""
+    rows = run_query2json(database["name"], "sales", config=database["config"])
+    assert all(isinstance(r["amount"], Decimal) for r in rows)
+
+
+def test_bind_parameter_filters_rows(database):
+    """`:min_amount` bind parameter filters server-side."""
+    rows = run_query2json(
+        database["name"], "sales_by_month", config=database["config"], min_amount=5000
+    )
+    assert sorted(r["month"] for r in rows) == ["January", "March"]
+
+
+def test_json_dumps_handles_decimal(database):
+    """Library-level serialization turns Decimal into JSON without raising."""
+    rows = run_query2json(database["name"], "sales", config=database["config"])
+    assert json.loads(json_dumps(rows))[0]["amount"] == 5000.0
+
+
+def test_cli_json_serialization_decimal_to_float(database):
+    """End-to-end CLI run emits valid JSON with Decimal rendered as float."""
+    result = run_cli(
+        "--name", database["name"], "--query", "sales", "--config", database["config"]
+    )
+    assert result.returncode == 0, result.stderr
+    by_month = {r["month"]: r["amount"] for r in json.loads(result.stdout)}
+    assert by_month["January"] == 5000.0
+    assert isinstance(by_month["January"], float)

--- a/uv.lock
+++ b/uv.lock
@@ -431,6 +431,69 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4", size = 3712314, upload-time = "2026-04-20T23:33:31.363Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56", size = 3822389, upload-time = "2026-04-20T23:33:34.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/30575e75f14d5351a56a1971bb43fe7f8bf7edf1b654fb1bec65c42a8812/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433", size = 4578448, upload-time = "2026-04-20T23:33:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e", size = 4273705, upload-time = "2026-04-20T23:33:39.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/c566803818eb03161ba869b6ba612bf7ad56816d98b9e5121e0a22ad6b0b/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3", size = 5893784, upload-time = "2026-04-20T23:33:41.658Z" },
+    { url = "https://files.pythonhosted.org/packages/63/fe/0dfa5797e0b229e0567bc378695224caf14d547f73b05be0c80549089772/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4", size = 4109306, upload-time = "2026-04-20T23:33:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/89/28063adf17a4ba501eedd9890feab0c649ee4d8bd0a97df0ff1e9584feab/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256", size = 3654400, upload-time = "2026-04-20T23:33:46.115Z" },
+    { url = "https://files.pythonhosted.org/packages/84/94/5a01de0aa4ead0b8d8d1aa4ec18cec0bd36d03fa714eaa5bb8a0b1b50020/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c", size = 3299215, upload-time = "2026-04-20T23:33:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/85/723bb085a61c6ac2dc0a0043f375f2fe7365363e27b073bad56ca5bda979/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463", size = 3047724, upload-time = "2026-04-20T23:33:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/67/4d8b1e0d2fc4166677380eac0edf9cdff91013aca2546e8ef7bc04b56158/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1", size = 3349183, upload-time = "2026-04-20T23:33:59.635Z" },
+    { url = "https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03", size = 2757036, upload-time = "2026-04-20T23:34:01.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -455,6 +518,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
 ]
 
 [[package]]
@@ -630,6 +702,10 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
 ]
+integration = [
+    { name = "psycopg2-binary" },
+    { name = "pymysql" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -638,11 +714,13 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=3.7.9" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.761" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "psycopg2-binary", marker = "extra == 'integration'", specifier = ">=2.9" },
+    { name = "pymysql", marker = "extra == 'integration'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=5.3.2" },
     { name = "python-dateutil", specifier = ">=2.8.1" },
     { name = "sqlalchemy", specifier = ">=1.3.12" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "integration"]
 
 [[package]]
 name = "sqlalchemy"


### PR DESCRIPTION
## Summary

Adds real-database integration coverage for the documented PostgreSQL and MySQL demo paths (FRA-167), while keeping the fast unit suite Docker-free.

- New `tests/integration/` suite covering **named connection lookup, named query lookup, bind parameters, Decimal/numeric values, and JSON serialization** (library + end-to-end CLI), parametrized over PostgreSQL and MySQL.
- Marked `integration` and **deselected by default** (`addopts = "-m 'not integration'"`), so `uv run pytest` stays fast and needs no Docker.
- `database` fixture reuses the named queries from `docker/config.json` and maps connections to `127.0.0.1` URLs (overridable via `SQL2JSON_TEST_PG_URL` / `SQL2JSON_TEST_MYSQL_URL`). Tests **skip cleanly** when a DB is unreachable or its driver is missing.
- `scripts/test-integration.sh` — one command that provisions the compose services, runs the suite, and tears down.
- `.github/workflows/ci.yml` — separate `unit` and `integration` jobs; the integration job provisions the services.
- New `integration` extra (`psycopg2-binary`, `pymysql`); README, CLAUDE.md, and CHANGELOG updated.

## Test plan

- `uv run pytest` → 120 passed, 12 deselected (Docker-free).
- No DB running → 12 skipped (clean skip).
- `./scripts/test-integration.sh` → 12 passed against real PostgreSQL 16 + MySQL 8.0.
- `flake8` clean; `black` formatted.

Closes FRA-167.