### PR TITLE
ci: install dev extra so flake8 and pytest resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - name: Install dependencies
-        run: uv sync
       - name: Lint
-        run: uv run flake8
+        run: uv run --extra dev flake8
       - name: Run unit tests
-        run: uv run pytest
+        run: uv run --extra dev pytest
 
   integration:
     name: Database integration (PostgreSQL + MySQL)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -54,4 +54,5 @@ if ! docker compose up -d --wait "${services[@]}" 2>/dev/null; then
 fi
 
 echo ">> Running integration tests..."
-uv run --extra integration pytest -m integration tests/integration "$@"
+# `dev` provides pytest; `integration` provides the psycopg2 / pymysql drivers.
+uv run --extra dev --extra integration pytest -m integration tests/integration "$@"


### PR DESCRIPTION
## Summary

The CI added in #11 failed on `master`: both jobs ran `uv`/`uv run` without the `dev` extra, so `flake8` (Lint) and `pytest` (unit + integration) weren't installed in a clean runner and the steps errored with `Failed to spawn`. It passed locally only because the dev `.venv` already had them.

- Unit job: lint and tests now run via `uv run --extra dev`.
- Integration script: runs pytest via `uv run --extra dev --extra integration` (`dev` provides pytest, `integration` provides the psycopg2/pymysql drivers).

## Test plan

- `uv run --extra dev flake8` → clean.
- `uv run --extra dev pytest` → 120 passed, 12 deselected.
- `uv run --extra dev --extra integration pytest -m integration tests/integration` → resolves pytest (12 skipped without DB; 12 passed against live services via `./scripts/test-integration.sh`).