### PR TITLE
docs: public GitHub/PyPI hygiene — LICENSE, SECURITY, RELEASING, packaging metadata (FRA-169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Real-database integration test suite (`tests/integration/`) covering the PostgreSQL and MySQL demo paths: named connection lookup, named query lookup, bind parameters, Decimal values, and JSON serialization. Tests are marked `integration` and deselected by default, so `uv run pytest` stays fast and Docker-free. Run them with `./scripts/test-integration.sh` (provisions the `docker-compose.yml` services, runs the suite, tears down) or `uv run --extra integration pytest -m integration tests/integration` against already-running services. Each test skips cleanly when its database is unreachable. A `.github/workflows/ci.yml` `integration` job provisions the services in CI.
 - Explicit `__all__` exports for the supported top-level Python API and `sql2json.parameter` surface.
 - Python API documentation and runnable examples under `examples/python_api`.
+- Project hygiene for public GitHub/PyPI: `LICENSE` (MIT), `SECURITY.md` (security model and private vulnerability reporting), and `RELEASING.md` (maintainer-only release process).
+- Packaging metadata in `pyproject.toml`: `readme`, `license`/`license-files`, keywords, trove classifiers, and `[project.urls]` (Homepage, Repository, Issues, Changelog) so PyPI links to source, issues, docs, and license.
+- User-facing database driver extras: `pip install "sql2json[postgres]"` (psycopg2-binary) and `sql2json[mysql]` (PyMySQL).
 - `--timezone` flag: accepts an IANA timezone name (e.g. `--timezone America/New_York`, `--timezone UTC`) and uses it when resolving `CURRENT_DATE`, `START_CURRENT_MONTH`, and all other date variables. Defaults to local system timezone (backward-compatible). An invalid timezone name produces a structured JSON error on stderr and a non-zero exit code.
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,17 @@
 # Contributing to sql2json
 
-Thanks for contributing! This project runs a set of automated quality gates on
-every pull request and on pushes to `master` (see
+Thanks for contributing! External contributors are welcome to open issues and
+pull requests. This project runs a set of automated quality gates on every pull
+request and on pushes to `master` (see
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml)). Running them locally
 before you push keeps the feedback loop fast.
+
+> **Releases are maintainer-only.** Anyone may propose changes, but bumping the
+> version, tagging, and publishing to PyPI are reserved for the project
+> maintainer (see [RELEASING.md](RELEASING.md)). Please do not bump the version
+> in a PR — if you think a release is warranted, open an issue requesting one.
+> Found a security issue? See [SECURITY.md](SECURITY.md) — do not open a public
+> issue for it.
 
 ## Setup
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Francisco Perez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 pip install sql2json
 ```
 
+SQLite works out of the box (it ships with Python). For PostgreSQL or MySQL,
+install the matching driver extra:
+
+```bash
+pip install "sql2json[postgres]"   # psycopg2-binary
+pip install "sql2json[mysql]"      # PyMySQL
+pip install "sql2json[postgres,mysql]"
+```
+
+Other databases work too — install any
+[SQLAlchemy-supported driver](https://docs.sqlalchemy.org/en/20/dialects/) (e.g.
+`pyodbc` for MS SQL Server) alongside `sql2json`.
+
 ## Docker
 
 The image includes drivers for PostgreSQL (`psycopg2-binary`) and MySQL / MariaDB (`PyMySQL`) in addition to SQLite, which is built into Python.
@@ -467,3 +480,19 @@ See [examples/python_api](examples/python_api) for runnable examples covering na
 `sql2json` is designed to be called as a subprocess by AI agents and LLMs. It outputs clean JSON to stdout, structured errors to stderr, and supports discovery commands so an agent can orient itself before querying.
 
 See [AGENTS.md](AGENTS.md) for the full agent integration guide, including discovery flags, error handling, the Python API, and security notes.
+
+## Contributing
+
+Issues and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for
+local setup and the quality gates. Releases are maintainer-only
+([RELEASING.md](RELEASING.md)).
+
+## Security
+
+`sql2json` executes the SQL it is given and config files may contain database
+credentials. See [SECURITY.md](SECURITY.md) for the security model and how to
+report a vulnerability privately.
+
+## License
+
+[MIT](LICENSE) © Francisco Perez

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,78 @@
+# Releasing sql2json
+
+**This is a maintainer-only process.** Releases to [PyPI](https://pypi.org/project/sql2json/)
+are published exclusively by the project maintainer. External contributors are
+welcome to open issues and pull requests, but cutting and publishing a release
+(version bumps, tags, and PyPI uploads) is reserved for the maintainer.
+
+If you are a contributor and believe a release is warranted, open an issue
+requesting one rather than bumping the version yourself.
+
+## Prerequisites (maintainer)
+
+- Push access to `master` and permission to create tags.
+- A PyPI account with upload rights to the `sql2json` project, and a token
+  configured via `UV_PUBLISH_TOKEN` or `~/.pypirc`.
+- `uv` installed locally.
+
+## Checklist
+
+1. **Bump the version** in `pyproject.toml`:
+
+   ```toml
+   version = "0.2.1"
+   ```
+
+   `sql2json` is pre-1.0 and follows [Semantic Versioning](https://semver.org/)
+   with the pre-1.0 convention that **breaking changes ship in a minor bump**
+   (e.g. `0.2.x → 0.3.0`), not a major. The version is single-sourced: the
+   package reads it at runtime via `importlib.metadata.version("sql2json")`, so
+   `pyproject.toml` is the only place to edit.
+
+2. **Update `CHANGELOG.md`** — move the `[Unreleased]` entries into a new dated
+   `[0.2.1]` section at the top, following
+   [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+3. **Run the full quality gates** (everything CI enforces):
+
+   ```bash
+   uv run --extra dev black --check .
+   uv run --extra dev flake8
+   uv run --extra dev mypy
+   uv run --extra dev pytest --cov
+   ```
+
+4. **Commit** the version bump and changelog:
+
+   ```bash
+   git add pyproject.toml CHANGELOG.md
+   git commit -m "chore: bump version to 0.2.1"
+   ```
+
+5. **Tag** (always prefix with `v`):
+
+   ```bash
+   git tag v0.2.1
+   ```
+
+6. **Push the commit and tag together**:
+
+   ```bash
+   git push origin master --tags
+   ```
+
+7. **Build and publish to PyPI**:
+
+   ```bash
+   uv build      # produces dist/sql2json-0.2.1.tar.gz and the wheel
+   uv publish    # uploads to PyPI
+   ```
+
+## Notes
+
+- Build artifacts (`dist/`, `*.egg-info/`) are in `.gitignore` — never commit
+  them.
+- The build backend is **hatchling** (set in `pyproject.toml`). Do not use
+  `python setup.py` or `setuptools` commands.
+- Verify the published release at <https://pypi.org/project/sql2json/> and that
+  `pip install sql2json==0.2.1` resolves the new version.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported versions
+
+`sql2json` is pre-1.0 (`0.x`). Security fixes are applied to the latest released
+version only. Please upgrade to the most recent release before reporting an
+issue.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use [GitHub's private vulnerability reporting](https://github.com/fsistemas/sql2json/security/advisories/new)
+(the **"Report a vulnerability"** button under the repository's **Security**
+tab). This opens a private advisory visible only to the maintainer.
+
+When reporting, please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof of concept.
+- The `sql2json` version and your environment (OS, Python version, database driver).
+
+You can expect an initial acknowledgement within a reasonable timeframe. This is
+a small, maintainer-run project, so please be patient. Once a fix is available,
+the maintainer will coordinate disclosure with you.
+
+## Security model — what you are responsible for
+
+`sql2json` is a thin wrapper that executes the SQL it is given against a
+database you configure. Understanding the trust boundary is essential to using
+it safely.
+
+### SQL execution risk
+
+- **The tool executes whatever SQL it receives.** Inline SQL passed via
+  `--query`, SQL loaded from `@/path/file.sql`, and named queries from your
+  config are all run as-is. There is no allow-list, sandbox, or read-only
+  enforcement.
+- **Bind parameters are parameterized, but the query text is not.** Values
+  passed as `--<param>` flags are bound safely as SQL parameters (`:param`).
+  However, the query string itself is fully under the caller's control — never
+  build a query string from untrusted input and pass it to `--query`.
+- **Restrict at the database layer.** If you need read-only access, connect with
+  a database user that only has `SELECT` privileges. `sql2json` will not stop a
+  privileged connection from running `DELETE`, `DROP`, or `UPDATE`.
+- **Prefer named queries** from your config file over inline SQL when exposing
+  the tool to automation or agents — it limits the SQL surface to queries you
+  have reviewed.
+
+### Credential handling
+
+- **Connection strings contain credentials.** Config files
+  (`~/.sql2json/config.json` and the lookup-order alternatives) and raw
+  SQLAlchemy URLs passed via `--name` may embed usernames and passwords. Treat
+  these files as secrets: restrict their permissions and keep them out of
+  version control.
+- **The demo credentials are for local Docker only.** The `demo`/`demo` (and
+  MySQL `root`) credentials in `docker-compose.yml`, `docker/config.json`, and
+  the README exist solely for the local demo stack, whose ports bind to
+  `127.0.0.1`. Never reuse them for any reachable database.
+- **Be careful with shell history and logs.** Passing a connection URL inline
+  via `--name` can leak it into shell history, process listings, and CI logs.
+  Prefer a config file with appropriate file permissions.
+
+### Untrusted output
+
+- Query results are serialized to JSON/CSV/Excel as-is. If results contain
+  attacker-controlled content, treat the output as untrusted when feeding it
+  into downstream systems (spreadsheets, dashboards, shells).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,41 @@
 name = "sql2json"
 version = "0.2.0"
 description = "Tool to run a SQL query and convert result to JSON"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "Francisco Perez", email = "fsistemas@gmail.com" }
+]
+keywords = ["sql", "json", "csv", "sqlalchemy", "cli", "etl", "database"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Utilities",
 ]
 dependencies = [
     "SQLAlchemy>=1.3.12", "fire>=0.2.1", "python-dateutil>=2.8.1",
 ]
 requires-python = ">=3.10"
 
+[project.urls]
+Homepage = "https://github.com/fsistemas/sql2json"
+Repository = "https://github.com/fsistemas/sql2json"
+Issues = "https://github.com/fsistemas/sql2json/issues"
+Changelog = "https://github.com/fsistemas/sql2json/blob/master/CHANGELOG.md"
+
 [project.optional-dependencies]
+# User-facing database driver extras: pip install "sql2json[postgres]" etc.
+postgres = ["psycopg2-binary>=2.9"]
+mysql = ["pymysql>=1.1"]
 dev = [
     "flake8>=3.7.9",
     "mypy>=0.761",
@@ -20,6 +46,7 @@ dev = [
     "pre-commit>=1.10",
     "types-python-dateutil>=2.8",
 ]
+# Drivers needed for the real-database integration suite (PostgreSQL + MySQL).
 integration = [
     "psycopg2-binary>=2.9",
     "pymysql>=1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -840,6 +840,12 @@ integration = [
     { name = "psycopg2-binary" },
     { name = "pymysql" },
 ]
+mysql = [
+    { name = "pymysql" },
+]
+postgres = [
+    { name = "psycopg2-binary" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -849,14 +855,16 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.761" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "psycopg2-binary", marker = "extra == 'integration'", specifier = ">=2.9" },
+    { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9" },
     { name = "pymysql", marker = "extra == 'integration'", specifier = ">=1.1" },
+    { name = "pymysql", marker = "extra == 'mysql'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=5.3.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "python-dateutil", specifier = ">=2.8.1" },
     { name = "sqlalchemy", specifier = ">=1.3.12" },
     { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8" },
 ]
-provides-extras = ["dev", "integration"]
+provides-extras = ["postgres", "mysql", "dev", "integration"]
 
 [[package]]
 name = "sqlalchemy"


### PR DESCRIPTION
## Summary

Makes the project safer and easier for external users/contributors now that it's public, per FRA-169. No runtime code changes — docs and packaging metadata only.

## Changes

- **LICENSE** — MIT (`Copyright (c) 2026 Francisco Perez`).
- **SECURITY.md** — security model (SQL execution risk, credential handling, demo-credentials scoping, untrusted output) and private vulnerability reporting via GitHub Security Advisories.
- **RELEASING.md** — maintainer-only release/publish process (version bump, changelog, quality gates, tag, `uv build`/`uv publish`). Lifted from internal notes into public, reproducible docs.
- **CONTRIBUTING.md** — clarifies external contributors may open issues/PRs but release authority stays with the maintainer; links SECURITY/RELEASING.
- **pyproject.toml** — `readme`, MIT `license`/`license-files`, keywords, trove classifiers, `[project.urls]` (Homepage/Repository/Issues/Changelog), and user-facing driver extras `[postgres]` (psycopg2-binary) and `[mysql]` (PyMySQL).
- **README.md** — install extras, plus Contributing/Security/License sections.

## Review notes

Reviewed README/AGENTS/docs for private machine paths, secrets, and private Linear references — none found. The `.claude/` symlink is gitignored; demo credentials were already scoped to the local `127.0.0.1` Docker stack and SECURITY.md now states that explicitly.

## Acceptance criteria

- [x] Public docs contain no private/local machine paths or secrets
- [x] Demo credentials explicitly scoped to local Docker only
- [x] PyPI metadata sufficient to find source, issues, docs, license
- [x] Release steps documented as maintainer-only, no private workflow knowledge
- [x] Contributor docs clarify release/publish authority stays with maintainer

## Verification

- `uv build` succeeds; wheel METADATA confirmed to carry License-Expression, License-File, Project-URLs, classifiers, keywords, and the `postgres`/`mysql` extras
- `black --check`, `flake8` clean; `pytest` 120 passed