### PR TITLE
feat: allow --wrapper to accept a custom key name (FRA-176)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test.db
 .claude/
 .coverage
 htmlcov/
+.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Query values prefixed with `@` are treated as file paths to `.sql` files.
 | `--first` | Return only the first row |
 | `--key` | Extract a single column as the value (or use as dict key with `--value`) |
 | `--value` | Used with `--key` to produce `{key_col: value_col}` dicts |
-| `--wrapper` | Wrap the result list in `{"data": [...]}` |
+| `--wrapper` | Wrap the result. `True`/bare flag wraps under `{"data": [...]}`; a non-empty string wraps under that key (`--wrapper items` → `{"items": [...]}`); `False`/`""` returns it unwrapped |
 | `--jsonkeys` | Comma-separated column names whose string values should be parsed as JSON |
 | `--format` | `json` (default), `csv`, or `excel` |
 | `--output` | Save to file instead of printing; filename supports `{CURRENT_DATE}` etc. |

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ python -m sql2json [options] [--param value ...]
 | `--first` | `False` | Return only the first row (object, not array) |
 | `--key` | `""` | Extract one column as value (scalar with `--first`), or dict key (with `--value`) |
 | `--value` | `""` | Used with `--key` to produce `{key_col: value_col}` dicts |
-| `--wrapper` | `False` | Wrap result in `{"data": [...]}` |
+| `--wrapper` | `False` | Wrap result in `{"data": [...]}` (bare `--wrapper`/`True`); pass a string (e.g. `--wrapper=items`) to wrap under a custom key: `{"items": [...]}` |
 | `--jsonkeys` | `""` | Comma-separated columns whose string values should be parsed as JSON |
 | `--format` | `json` | Output format: `json`, `csv`, `excel` |
 | `--output` | _(stdout)_ | Save to file; filename supports `{CURRENT_DATE}` etc. |
@@ -362,6 +362,20 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 ```json
 {
     "data": [
+        {"month": "January", "sales": 5000},
+        {"month": "February", "sales": 3000}
+    ]
+}
+```
+
+Pass a string to wrap under a custom key instead of `data`:
+
+```bash
+python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --wrapper=items
+```
+```json
+{
+    "items": [
         {"month": "January", "sales": 5000},
         {"month": "February", "sales": 3000}
     ]

--- a/examples/python_api/output_shapes.py
+++ b/examples/python_api/output_shapes.py
@@ -8,3 +8,4 @@ print(
     run_query2json(name="sqlite:///:memory:", query=query, key="month", value="sales")
 )
 print(run_query2json(name="sqlite:///:memory:", query=query, wrapper=True))
+print(run_query2json(name="sqlite:///:memory:", query=query, wrapper="items"))

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -122,6 +122,15 @@ sql2json --name mydb --query 'SELECT id, name FROM users' --key id --value name
 # → {"1": "Alice", "2": "Bob"}
 ```
 
+**Wrap rows under a top-level key** (handy for dashboard/API payloads):
+
+```bash
+sql2json --name mydb --query users --wrapper          # → {"data": [...]}
+sql2json --name mydb --query users --wrapper items     # → {"items": [...]}
+```
+
+`--wrapper` (bare) wraps under `"data"`; pass a name (`--wrapper items`) to wrap under that key instead. Omit it for a bare array.
+
 ## Docker
 
 Run without installing anything locally:

--- a/sql2json/sql2json.py
+++ b/sql2json/sql2json.py
@@ -162,7 +162,7 @@ def parse_json_columns(result: dict, jsonkeys: str = "") -> dict:
 def run_query2json(
     name: str = "default",
     query: str = "default",
-    wrapper: bool = False,
+    wrapper: Union[bool, str] = False,
     first: bool = False,
     key: str = "",
     value: str = "",
@@ -175,7 +175,9 @@ def run_query2json(
 
     name: Connection name in config file or a SQLAlchemy connection string.
     query: Query name in config file, raw SQL, or @/path/to/file.sql.
-    wrapper: Wrap result list in {"data": [...]}.
+    wrapper: Wrap result list. True wraps under "data" ({"data": [...]}); a
+        non-empty string wraps under that key (e.g. "items" -> {"items": [...]});
+        False or "" returns the result unwrapped.
     first: Return only the first row.
     key: Column name to use as key (with value) or extract as scalar (with first).
     value: Column name to use as value (used with key).
@@ -213,7 +215,9 @@ def run_query2json(
                 item.get(key) if key and key in item else item for item in results
             ]
 
-    if wrapper:
+    if isinstance(wrapper, str) and wrapper:
+        return {wrapper: result}
+    elif wrapper:
         return {"data": result}
     else:
         return result

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -82,6 +82,45 @@ class TestWrapper:
         result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper=True, first=True)
         assert result == {"data": {"month": "January", "sales": 5000}}
 
+    def test_wrapper_string_uses_custom_key(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper="items")
+        assert result == {
+            "items": [
+                {"month": "January", "sales": 5000},
+                {"month": "February", "sales": 3000},
+            ]
+        }
+
+    def test_wrapper_string_with_first(self):
+        result = run_query2json(
+            name=MEMORY, query=TWO_ROWS, wrapper="items", first=True
+        )
+        assert result == {"items": {"month": "January", "sales": 5000}}
+
+    def test_wrapper_empty_string_does_not_wrap(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper="")
+        assert result == [
+            {"month": "January", "sales": 5000},
+            {"month": "February", "sales": 3000},
+        ]
+
+    def test_wrapper_false_does_not_wrap(self):
+        result = run_query2json(name=MEMORY, query=TWO_ROWS, wrapper=False)
+        assert result == [
+            {"month": "January", "sales": 5000},
+            {"month": "February", "sales": 3000},
+        ]
+
+    def test_wrapper_string_wraps_transformed_key_value_result(self):
+        result = run_query2json(
+            name=MEMORY,
+            query=TWO_ROWS,
+            wrapper="items",
+            key="month",
+            value="sales",
+        )
+        assert result == {"items": [{"January": 5000}, {"February": 3000}]}
+
 
 class TestJsonKeys:
     def test_string_column_is_parsed_into_object(self):


### PR DESCRIPTION
## Summary

Extends `--wrapper` so it accepts a non-empty **string** naming the wrapper key, in addition to the existing boolean. Fully backward compatible.

| Input | Result |
|---|---|
| omitted / `False` / `""` | `[...]` — unwrapped (unchanged) |
| `True` / bare `--wrapper` | `{"data": [...]}` (unchanged) |
| `--wrapper items` | `{"items": [...]}` (**new**) |

Wrapping applies around whatever `result` ends up being (list, dict, or scalar), the same whether or not `--first` is used.

## Changes

- `sql2json/sql2json.py` — `run_query2json` `wrapper: Union[bool, str] = False`; resolves a string key vs. the literal `"data"`; docstring updated.
- `tests/test_transformations.py` — 5 new `TestWrapper` tests (custom key, with `first`, combined with `key`/`value`, plus empty-string and explicit-`False` regression guards). Existing wrapper tests unchanged.
- Docs — `README.md` (flags table + dashboard example), `CLAUDE.md` (transformations table), and the canonical sql2json skill (`skills/sql2json/SKILL.md`).
- `examples/python_api/output_shapes.py` — added a `wrapper="items"` line demonstrating the custom key.
- `.gitignore` — add `.idea/`.

## Testing

- `uv run pytest` — 125 passed, 12 deselected
- `uv run flake8` — clean
- `uv run --extra dev mypy` — clean (`Union[bool, str]` type-checks)
- `uv run --extra dev pytest --cov` — 97.21%, above the 90% gate
- Ran `examples/python_api/output_shapes.py` — custom key prints `{'items': [...]}`

Closes FRA-176.