### PR TITLE
feat: add sql2json console entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 `sql2json` runs SQL queries via SQLAlchemy and outputs JSON or CSV to stdout. It is invoked as a CLI tool or imported as a Python package — no framework coupling, no MCP server required.
 
+> **Invocation:** examples below use the `sql2json` command, available **since v0.2.1**. On `0.2.0` and earlier — or when the package's scripts directory is not on `PATH` — substitute the equivalent `python -m sql2json ...` form.
+
 ---
 
 ## Strategy for Agents
@@ -21,11 +23,11 @@ Before calling a query, an agent can inspect what is configured:
 
 ```bash
 # List available database connections
-python -m sql2json --list-connections --config /path/to/config.json
+sql2json --list-connections --config /path/to/config.json
 # → ["default", "mysql", "reporting"]
 
 # List available named queries
-python -m sql2json --list-queries --config /path/to/config.json
+sql2json --list-queries --config /path/to/config.json
 # → ["default", "sales_monthly", "total_users"]
 ```
 
@@ -113,25 +115,25 @@ Extra kwargs become SQL bind parameters (`:param_name` in the query). Values tha
 
 ```bash
 # Run a named query with a date parameter
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 
 # Run inline SQL directly
-python -m sql2json --name mysql --query "SELECT COUNT(*) AS total FROM orders WHERE date >= :since" --since "CURRENT_DATE-7"
+sql2json --name mysql --query "SELECT COUNT(*) AS total FROM orders WHERE date >= :since" --since "CURRENT_DATE-7"
 
 # Return only the first row, extract a single column value
-python -m sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first --key sales
+sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first --key sales
 
 # Return results as {key_col: value_col} pairs
-python -m sql2json --name mysql --query sales_monthly --key month --value sales
+sql2json --name mysql --query sales_monthly --key month --value sales
 
 # Wrap in {"data": [...]} for downstream systems
-python -m sql2json --name mysql --query sales_monthly --wrapper
+sql2json --name mysql --query sales_monthly --wrapper
 
 # Load query from a .sql file
-python -m sql2json --name mysql --query "@/path/to/my_query.sql" --min_age 18
+sql2json --name mysql --query "@/path/to/my_query.sql" --min_age 18
 
 # Save output to a dated CSV file
-python -m sql2json --name mysql --query sales_monthly --format csv --output sales_{CURRENT_DATE}
+sql2json --name mysql --query sales_monthly --format csv --output sales_{CURRENT_DATE}
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-19
+
+### Added
+- `sql2json` console entry point (`[project.scripts]` → `sql2json.__main__:main`), so the tool can be run as a plain `sql2json ...` command after install instead of only `python -m sql2json ...`. The `python -m sql2json` form continues to work unchanged. This also enables isolated global installs via `pipx install sql2json` / `uv tool install sql2json`.
+
 ## [0.2.0] - 2026-06-15
 
 > **`0.2.0` is a minor bump that ships breaking changes under the pre-1.0 SemVer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ uv run --extra dev mypy
 # Tests with coverage (gated at 90% via fail_under in pyproject.toml)
 uv run --extra dev pytest --cov
 
-# Run the CLI tool
-python -m sql2json --name default --query default
+# Run the CLI tool (since 0.2.1; `python -m sql2json ...` is equivalent)
+sql2json --name default --query default
 
 # Build Docker image
 docker build -t sql2json .
@@ -39,7 +39,7 @@ docker build -t sql2json .
 
 ## Architecture
 
-`sql2json` is a CLI tool that runs SQL queries via SQLAlchemy and outputs JSON, CSV, or Excel. It is invoked as `python -m sql2json` (entry point: `__main__.py` using `fire`).
+`sql2json` is a CLI tool that runs SQL queries via SQLAlchemy and outputs JSON, CSV, or Excel. Since 0.2.1 it is invoked as the `sql2json` console command (declared in `[project.scripts]`, target `sql2json.__main__:main`); the equivalent `python -m sql2json` form still works. Both dispatch through `fire`.
 
 ### Data flow
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Run SQL queries and get JSON (or CSV) on stdout — pipe it anywhere.
 `sql2json` connects to any SQLAlchemy-supported database, executes a query, and writes the results as JSON to standard output. No server, no framework, no boilerplate.
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 # → [{"month": "January", "sales": 5000}, {"month": "February", "sales": 3000}]
 ```
 
@@ -35,6 +35,28 @@ pip install "sql2json[postgres,mysql]"
 Other databases work too — install any
 [SQLAlchemy-supported driver](https://docs.sqlalchemy.org/en/20/dialects/) (e.g.
 `pyodbc` for MS SQL Server) alongside `sql2json`.
+
+### Running it
+
+Once installed, invoke the tool directly:
+
+```bash
+sql2json --name default --query default
+```
+
+The `sql2json` command is available **since v0.2.1**. The original
+`python -m sql2json ...` form still works and is equivalent — use it on `0.2.0`
+and earlier, or whenever the package is installed but its scripts directory is
+not on your `PATH`.
+
+For a global, isolated install that puts `sql2json` on your `PATH` without
+touching your project environments:
+
+```bash
+pipx install sql2json
+# or
+uv tool install sql2json
+```
 
 ## Docker
 
@@ -202,14 +224,14 @@ EOF
 **2. Run a query:**
 
 ```bash
-python -m sql2json
+sql2json
 # → [{"a": 1, "b": 2}]
 ```
 
 **3. Try inline SQL:**
 
 ```bash
-python -m sql2json --name default --query "SELECT date('now') AS today"
+sql2json --name default --query "SELECT date('now') AS today"
 # → [{"today": "2026-05-16"}]
 ```
 
@@ -248,7 +270,7 @@ Connection strings follow [SQLAlchemy URL format](https://docs.sqlalchemy.org/en
 ## CLI reference
 
 ```bash
-python -m sql2json [options] [--param value ...]
+sql2json [options] [--param value ...]
 ```
 
 | Flag | Default | Description |
@@ -273,10 +295,10 @@ Extra `--key value` flags become SQL bind parameters (`:key` in your query).
 Before writing a query, inspect what is configured:
 
 ```bash
-python -m sql2json --list-connections
+sql2json --list-connections
 # → ["default", "mysql", "reporting"]
 
-python -m sql2json --list-queries
+sql2json --list-queries
 # → ["default", "sales_monthly", "total_sales"]
 ```
 
@@ -315,7 +337,7 @@ START_CURRENT_YEAR-1    → first day of last year
 ### Array of objects (default)
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 ```
 ```json
 [
@@ -327,7 +349,7 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 ### First row only (`--first`)
 
 ```bash
-python -m sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first
+sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first
 ```
 ```json
 {"sales": 500}
@@ -336,7 +358,7 @@ python -m sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10
 ### Single value (`--first --key`)
 
 ```bash
-python -m sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first --key sales
+sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10" --first --key sales
 ```
 ```
 500
@@ -345,7 +367,7 @@ python -m sql2json --name mysql --query total_sales --date_from "CURRENT_DATE-10
 ### Key-value pairs (`--key --value`)
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --key month --value sales
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --key month --value sales
 ```
 ```json
 [
@@ -357,7 +379,7 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 ### Wrapped for dashboards (`--wrapper`)
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --wrapper
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --wrapper
 ```
 ```json
 {
@@ -371,7 +393,7 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 Pass a string to wrap under a custom key instead of `data`:
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --wrapper=items
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --wrapper=items
 ```
 ```json
 {
@@ -387,7 +409,7 @@ python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT
 When a column contains a JSON string from a database JSON function, use `--jsonkeys` to parse it:
 
 ```bash
-python -m sql2json --name mysql --query json_report --jsonkeys "payload,metadata"
+sql2json --name mysql --query json_report --jsonkeys "payload,metadata"
 ```
 
 Without `--jsonkeys` those columns would be escaped strings; with it they are inlined as JSON.
@@ -397,17 +419,17 @@ Without `--jsonkeys` those columns would be escaped strings; with it they are in
 No need to define every query in the config file:
 
 ```bash
-python -m sql2json --name mysql --query "SELECT NOW() AS ts" --first --key ts
+sql2json --name mysql --query "SELECT NOW() AS ts" --first --key ts
 ```
 
 ### External `.sql` file
 
 ```bash
 # Defined in config.json as "@/path/to/file.sql"
-python -m sql2json --name mysql --query long_query --min_age 18
+sql2json --name mysql --query long_query --min_age 18
 
 # Or pass the path directly
-python -m sql2json --name mysql --query "@/path/to/my_query.sql" --min_age 18
+sql2json --name mysql --query "@/path/to/my_query.sql" --min_age 18
 ```
 
 ## File output
@@ -416,26 +438,26 @@ Use `--output` to write to a file instead of stdout. The `--format` flag control
 
 ```bash
 # CSV file
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format csv --output Sales
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format csv --output Sales
 # → Sales.csv
 
 # Excel file
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format excel --output Sales
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format excel --output Sales
 # → Sales.xls
 
 # JSON file
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format json --output Sales
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1" --format json --output Sales
 # → Sales.json
 ```
 
 **Dated filenames** — use date variables in `--output`:
 
 ```bash
-python -m sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH" \
+sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH" \
     --format csv --output "Sales_{START_CURRENT_MONTH}_{CURRENT_DATE}"
 # → Sales_2026-05-01_2026-05-16.csv
 
-python -m sql2json --name mysql --query sales_monthly --date_from "CURRENT_DATE" \
+sql2json --name mysql --query sales_monthly --date_from "CURRENT_DATE" \
     --format csv --output "reports/Sales_{CURRENT_DATE}"
 # → reports/Sales_2026-05-16.csv
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sql2json"
-version = "0.2.0"
-description = "Tool to run a SQL query and convert result to JSON"
+version = "0.2.1"
+description = "CLI to run SQL queries on any SQLAlchemy database and output JSON, CSV, or Excel"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -26,6 +26,9 @@ dependencies = [
     "SQLAlchemy>=1.3.12", "fire>=0.2.1", "python-dateutil>=2.8.1",
 ]
 requires-python = ">=3.10"
+
+[project.scripts]
+sql2json = "sql2json.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/fsistemas/sql2json"

--- a/roadmap.md
+++ b/roadmap.md
@@ -48,10 +48,10 @@ exit code → 1
 Two new additive flags that output JSON to stdout and exit 0.
 
 ```bash
-python -m sql2json --list-connections
+sql2json --list-connections
 # → ["default", "mysql", "postgres"]
 
-python -m sql2json --list-queries
+sql2json --list-queries
 # → ["default", "sales_monthly", "total_sales"]
 ```
 

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -21,6 +21,10 @@ Install once, use from any project:
 pip install sql2json
 ```
 
+Examples here use the `sql2json` command, available since **v0.2.1**. On `0.2.0`
+and earlier — or if the command is not on `PATH` — use the equivalent
+`python -m sql2json ...` form instead.
+
 ## When to Use
 
 Use this skill when you need to:

--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -151,5 +151,9 @@ def handle_run_query2json(
         sys.exit(1)
 
 
-if __name__ == "__main__":
+def main():
     fire.Fire(handle_run_query2json)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ including fire arg parsing, discovery flags, and JSON error output.
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from decimal import Decimal
@@ -223,3 +224,28 @@ class TestTimezone:
         result = run_cli("--timezone", "Invalid/Zone", "--config", cfg)
         error = json.loads(result.stderr)
         assert "error" in error
+
+
+class TestEntryPoint:
+    """The `sql2json` console_scripts entry point (pyproject [project.scripts])."""
+
+    def test_main_dispatches_to_fire(self, monkeypatch):
+        import sql2json.__main__ as cli
+
+        called = {}
+        monkeypatch.setattr(cli.fire, "Fire", lambda fn: called.setdefault("fn", fn))
+        cli.main()
+        assert called["fn"] is cli.handle_run_query2json
+
+    def test_console_script_runs(self, tmp_path):
+        if shutil.which("sql2json") is None:
+            pytest.skip("sql2json console script not installed on PATH")
+        cfg = str(tmp_path / "config.json")
+        _write_config(cfg, CONFIG)
+        result = subprocess.run(
+            ["sql2json", "--config", cfg],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout)[0]["a"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "sql2json"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary

Adds a `sql2json` console entry point so the tool runs as a plain `sql2json ...` command after install, instead of only `python -m sql2json ...`. The `python -m` form keeps working unchanged.

- `[project.scripts]` in `pyproject.toml` → `sql2json.__main__:main`
- new module-level `main()` in `__main__.py` (the `if __name__` guard now calls it)
- enables isolated global installs via `pipx install sql2json` / `uv tool install sql2json`

## Docs

All command examples now prefer the bare `sql2json` form, with a short note on each surface explaining that the command is available since **v0.2.1** and that `python -m sql2json` remains equivalent (README, AGENTS.md, roadmap.md, CLAUDE.md, skill).

## Release

Patch bump `0.2.0` → `0.2.1` (additive, nothing breaks) with a CHANGELOG entry, ready to tag after merge. Also tightened the package `description` to mention CSV/Excel and SQLAlchemy.

## Tests

- `main()` dispatches to fire (unit)
- installed console script runs end-to-end (skips cleanly if not on PATH)
- full suite: 127 passed; black/flake8/mypy clean; coverage 97%