### PR TITLE
feat(docker): publish official sql2json image (FRA-204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Official Docker image published to [`docker.io/fsistemas/sql2json`](https://hub.docker.com/r/fsistemas/sql2json), so the tool can be run with `podman run docker.io/fsistemas/sql2json ...` (or `docker run ...`) without building from source. Currently published for `linux/amd64`; the release process documents the multi-arch (`+ linux/arm64`) publish path for when host emulation is available. Supported tags: `latest` (newest stable) and immutable `X.Y.Z` (pinned). Documented in the README "Docker" section.
+
+### Changed
+- The `Dockerfile` now installs `sql2json` from PyPI (build arg `VERSION` pins a release; omitted installs the latest) instead of copying the working tree, so a tagged image always matches the published release. Its entrypoint is now the `sql2json` console script (was `python -m sql2json`), and it carries OCI image labels.
+- Documented the local (Podman / Docker) image publish + verify step in `RELEASING.md` and CLAUDE.md, run after the PyPI publish.
+
 ## [0.2.1] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,11 @@ uv run --extra dev pytest --cov
 # Run the CLI tool (since 0.2.1; `python -m sql2json ...` is equivalent)
 sql2json --name default --query default
 
-# Build Docker image
-docker build -t sql2json .
+# Build the Docker image (installs sql2json from PyPI; pass VERSION to pin a
+# release, omit it for the latest). `podman build ...` works identically.
+docker build -t sql2json .                      # latest PyPI release
+docker build --build-arg VERSION=0.2.1 -t sql2json .
+# The official image is published at docker.io/fsistemas/sql2json (see RELEASING.md).
 ```
 
 ## Architecture
@@ -128,6 +131,8 @@ Query values prefixed with `@` are treated as file paths to `.sql` files.
    uv publish
    ```
    `uv build` produces `dist/sql2json-0.1.12.tar.gz` and the wheel. `uv publish` uploads to PyPI (requires a token configured via `UV_PUBLISH_TOKEN` or `~/.pypirc`).
+
+8. **Publish the Docker image** to `docker.io/fsistemas/sql2json` from your local machine (not CI). The image installs `sql2json==<version>` from PyPI, so this runs **after** step 7. The maintainer uses Podman; `docker buildx` is equivalent. Push the immutable `:X.Y.Z` tag every release and move `:latest` only for stable releases. See `RELEASING.md` for the full Podman/Docker commands and the verify step.
 
 ### Notes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,32 @@
-FROM python:3.10-slim
+# Official sql2json image.
+#
+# The package is installed from PyPI (not the working tree) so a tagged image
+# always matches the published release of the same version. Pass
+# `--build-arg VERSION=X.Y.Z` to pin a specific release; with no VERSION the
+# latest release on PyPI is installed.
+ARG PYTHON_VERSION=3.10-slim
+FROM python:${PYTHON_VERSION}
 
-WORKDIR /src
-COPY . /src
-RUN pip install --no-cache-dir . psycopg2-binary PyMySQL
+ARG VERSION=
 
+# PostgreSQL + MySQL/MariaDB drivers come from the package extras; SQLite is
+# built into Python. `${VERSION:+==${VERSION}}` expands to `==X.Y.Z` only when
+# VERSION is set, otherwise installs the latest release.
+RUN pip install --no-cache-dir "sql2json[postgres,mysql]${VERSION:+==${VERSION}}"
+
+LABEL org.opencontainers.image.title="sql2json" \
+      org.opencontainers.image.description="Run SQL queries via SQLAlchemy and output JSON, CSV, or Excel." \
+      org.opencontainers.image.source="https://github.com/fsistemas/sql2json" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}"
+
+# Run as an unprivileged user. The home directory holds the config
+# (`/home/app/.sql2json`) and `/workspace` is the writable working dir for
+# `--output` files; both are owned by `app`.
+RUN useradd --create-home --uid 1000 app \
+    && mkdir -p /workspace \
+    && chown app:app /workspace
+USER app
 WORKDIR /workspace
 
-ENTRYPOINT ["python", "-m", "sql2json"]
+ENTRYPOINT ["sql2json"]

--- a/README.md
+++ b/README.md
@@ -60,36 +60,54 @@ uv tool install sql2json
 
 ## Docker
 
-The image includes drivers for PostgreSQL (`psycopg2-binary`) and MySQL / MariaDB (`PyMySQL`) in addition to SQLite, which is built into Python.
+An official image is published to Docker Hub at
+[`docker.io/fsistemas/sql2json`](https://hub.docker.com/r/fsistemas/sql2json).
+It bundles drivers for PostgreSQL (`psycopg2-binary`) and MySQL / MariaDB
+(`PyMySQL`) in addition to SQLite, which is built into Python, and is built for
+both `linux/amd64` and `linux/arm64`.
 
-Build the image from the repository root:
+The examples below use [Podman](https://podman.io/); every command works
+identically with `docker` — just swap the executable name.
+
+Quick test without a config file (pulls the image on first run):
 
 ```bash
-docker build -t sql2json .
-```
-
-Quick test without a config file:
-
-```bash
-docker run --rm sql2json --query "SELECT 1 AS a, 2 AS b"
+podman run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
 # → [{"a": 1, "b": 2}]
 ```
+
+### Supported tags
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Newest **stable** release. Moves on every release — convenient, but not pinned. |
+| `X.Y.Z` (e.g. `0.2.1`) | A specific release. **Immutable** — recommended for production and CI. |
+
+```bash
+podman pull docker.io/fsistemas/sql2json:0.2.1   # pin a release
+podman pull docker.io/fsistemas/sql2json:latest  # newest stable
+```
+
+### Usage
+
+The image runs as an unprivileged user (`app`), whose home is `/home/app`, so
+config is read from `/home/app/.sql2json`.
 
 Run with your own config by mounting `~/.sql2json`:
 
 ```bash
-docker run --rm \
-  -v ~/.sql2json:/root/.sql2json \
-  sql2json --name default --query sales_monthly --date_from "START_CURRENT_MONTH-1"
+podman run --rm \
+  -v ~/.sql2json:/home/app/.sql2json \
+  docker.io/fsistemas/sql2json --name default --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 ```
 
 For SQLite, mount both the config directory and the database file. Point the connection string in your config to the in-container path:
 
 ```bash
-docker run --rm \
-  -v ~/.sql2json:/root/.sql2json \
+podman run --rm \
+  -v ~/.sql2json:/home/app/.sql2json \
   -v /path/to/mydb.sqlite:/data/mydb.sqlite \
-  sql2json --name default --query default
+  docker.io/fsistemas/sql2json --name default --query default
 ```
 
 ```json
@@ -100,22 +118,41 @@ docker run --rm \
 }
 ```
 
-Write output files by mounting a host directory to `/workspace`, the container working directory:
+Write output files by mounting a host directory to `/workspace`, the container working directory. Because the container runs as a non-root user, map the container user to your host user so the written files are owned by you — `--userns=keep-id` for Podman, `--user $(id -u):$(id -g)` for Docker:
 
 ```bash
-docker run --rm \
-  -v ~/.sql2json:/root/.sql2json \
+podman run --rm --userns=keep-id \
+  -v ~/.sql2json:/home/app/.sql2json \
   -v $(pwd)/reports:/workspace \
-  sql2json --name default --query sales_monthly \
+  docker.io/fsistemas/sql2json --name default --query sales_monthly \
     --format csv --output "Sales_{CURRENT_DATE}"
 # → ./reports/Sales_2026-05-17.csv on the host
+
+# Docker equivalent:
+docker run --rm --user $(id -u):$(id -g) \
+  -v ~/.sql2json:/home/app/.sql2json \
+  -v $(pwd)/reports:/workspace \
+  docker.io/fsistemas/sql2json --name default --query sales_monthly \
+    --format csv --output "Sales_{CURRENT_DATE}"
 ```
 
 MS SQL Server needs system-level ODBC libraries, so install the driver in a derived image:
 
 ```dockerfile
-FROM sql2json
+FROM docker.io/fsistemas/sql2json
 RUN pip install --no-cache-dir pyodbc
+```
+
+### Build from source (development)
+
+The published image installs `sql2json` from PyPI. To build an image from a
+local checkout instead — for example to try an unreleased change — pass the
+`VERSION` build arg (or omit it to install the latest PyPI release):
+
+```bash
+podman build -t sql2json .                       # latest PyPI release
+podman build --build-arg VERSION=0.2.1 -t sql2json .   # pin a release
+podman run --rm sql2json --query "SELECT 1 AS a, 2 AS b"
 ```
 
 ### Try it with docker compose

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,106 @@ requesting one rather than bumping the version yourself.
    uv publish    # uploads to PyPI
    ```
 
+8. **Publish the Docker image** to
+   [`docker.io/fsistemas/sql2json`](https://hub.docker.com/r/fsistemas/sql2json).
+
+   This runs from your local machine — it is **not** wired into CI. The image
+   installs `sql2json==<version>` from PyPI, so it must run **after** step 7 (the
+   version has to exist on PyPI first). Both Podman and Docker are shown; either
+   works.
+
+   First, log in to Docker Hub once (use a Docker Hub
+   [access token](https://hub.docker.com/settings/security) as the password,
+   not your account password):
+
+   ```bash
+   podman login docker.io   # username: fsistemas
+   # or: docker login docker.io
+   ```
+
+   **One-time setup for cross-arch builds.** Building a non-native architecture
+   (e.g. `linux/arm64` on an `amd64` host) requires `qemu-user-static`
+   registered as kernel `binfmt_misc` handlers. This is a **host-level** change
+   that needs real root — running the `tonistiigi/binfmt` installer inside a
+   *rootless* container does **not** work (the registration can't reach the host
+   kernel, and the build fails with `exec /bin/sh: Exec format error`). Install
+   it once with your distro package or as root:
+
+   ```bash
+   # Arch / Manjaro:
+   sudo pacman -S qemu-user-static qemu-user-static-binfmt
+   # Debian / Ubuntu:
+   sudo apt install qemu-user-static binfmt-support
+   # Or, as real root (not rootless), the portable installer:
+   sudo podman run --rm --privileged docker.io/tonistiigi/binfmt --install arm64
+   # Verify the handler is registered on the host:
+   ls /proc/sys/fs/binfmt_misc/ | grep qemu-aarch64
+   ```
+
+   **Podman** (multi-arch via a manifest list):
+
+   ```bash
+   podman manifest create docker.io/fsistemas/sql2json:0.2.1
+   podman build --platform linux/amd64,linux/arm64 \
+     --build-arg VERSION=0.2.1 \
+     --manifest docker.io/fsistemas/sql2json:0.2.1 .
+   podman manifest push docker.io/fsistemas/sql2json:0.2.1 \
+     docker.io/fsistemas/sql2json:0.2.1
+   # Stable releases only — also publish the moving `latest` tag:
+   podman manifest push docker.io/fsistemas/sql2json:0.2.1 \
+     docker.io/fsistemas/sql2json:latest
+   ```
+
+   **amd64-only fallback** (if qemu/arm64 emulation isn't available): publish a
+   single-arch image instead — still useful for most servers and CI. Re-publish
+   as multi-arch once the host is set up. Pass `--platform linux/amd64
+   --pull=always` to force the correct base image (see the cached-arch gotcha
+   below):
+
+   ```bash
+   podman build --platform linux/amd64 --pull=always --build-arg VERSION=0.2.1 \
+     -t docker.io/fsistemas/sql2json:0.2.1 \
+     -t docker.io/fsistemas/sql2json:latest .
+   podman push docker.io/fsistemas/sql2json:0.2.1
+   podman push docker.io/fsistemas/sql2json:latest   # stable releases only
+   ```
+
+   > **Cached-arch base-image gotcha.** After a cross-arch / multi-arch build
+   > attempt, your local image store can hold a *non-native* base image (e.g. an
+   > `arm64` `python:3.10-slim` pulled during an `--platform linux/arm64`
+   > experiment). Podman will silently reuse that cached base for a subsequent
+   > plain `podman build`, producing an image that fails to run with
+   > `exec /bin/sh: Exec format error` and a build-time warning like
+   > `image platform (linux/arm64/v8) does not match the expected platform
+   > (linux/amd64)`. Always build with an explicit `--platform` **and**
+   > `--pull=always` so the correct base image is fetched rather than reusing the
+   > wrong cached one. To inspect what's cached: `podman images --format
+   > '{{.Repository}}:{{.Tag}} {{.Arch}}'`.
+
+   **Docker** (`buildx` equivalent):
+
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 \
+     --build-arg VERSION=0.2.1 \
+     -t docker.io/fsistemas/sql2json:0.2.1 \
+     -t docker.io/fsistemas/sql2json:latest \
+     --push .
+   ```
+
+   **Tagging rules:** push the immutable `:0.2.1` tag every release; move
+   `:latest` **only** for stable releases (never for pre-releases / RCs). Treat
+   published version tags as write-once.
+
+   **Verify** the pushed image (either tool):
+
+   ```bash
+   podman pull docker.io/fsistemas/sql2json:0.2.1
+   podman run --rm docker.io/fsistemas/sql2json:0.2.1 --query "SELECT 1 AS a, 2 AS b"
+   # → [{"a": 1, "b": 2}]
+   podman run --rm --entrypoint pip docker.io/fsistemas/sql2json:0.2.1 \
+     show sql2json | grep ^Version   # must read: Version: 0.2.1
+   ```
+
 ## Notes
 
 - Build artifacts (`dist/`, `*.egg-info/`) are in `.gitignore` — never commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   sql2json:
     build: .
     volumes:
-      - ./docker/config.json:/root/.sql2json/config.json
+      - ./docker/config.json:/home/app/.sql2json/config.json
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Publish an official, pre-built `sql2json` image to Docker Hub (`docker.io/fsistemas/sql2json`) so users can `podman run` / `docker run` the tool without cloning and building from source.

- **Dockerfile**: installs `sql2json` from PyPI (build `ARG VERSION`; omitted = latest) instead of the working tree, so a tagged image matches the published release. Entrypoint is now the `sql2json` console script (was `python -m sql2json`), runs as an unprivileged `app` user, and carries OCI image labels.
- **README**: Docker section leads with the published image + a "Supported tags" note (`latest` moving / `X.Y.Z` immutable); non-root mount paths and `--userns=keep-id` / `--user` output-write notes.
- **RELEASING.md + CLAUDE.md**: local Podman/Docker image publish + verify step after the PyPI publish, including the cached-arch base-image gotcha (`--platform linux/amd64 --pull=always`).
- **docker-compose.yml**: config mounted under the non-root home.
- **CHANGELOG**: `[Unreleased]` entries.

## Published

`docker.io/fsistemas/sql2json:0.2.1` and `:latest` are live as **`linux/amd64`**.

## arm64 / multi-arch

arm64 is **not** in this release — blocked locally by per-user-namespace `binfmt_misc` isolation on the maintainer's kernel (6.12.91): rootless Podman containers don't consult the init-namespace QEMU handlers, so non-native `execve` fails with `Exec format error`. Full diagnosis and options (rootful local build / native arm64 host / optional CI) are documented on FRA-204. Tracked as a follow-up.