### PR TITLE
docs: document rootful Podman multi-arch image publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Official Docker image published to [`docker.io/fsistemas/sql2json`](https://hub.docker.com/r/fsistemas/sql2json), so the tool can be run with `podman run docker.io/fsistemas/sql2json ...` (or `docker run ...`) without building from source. Currently published for `linux/amd64`; the release process documents the multi-arch (`+ linux/arm64`) publish path for when host emulation is available. Supported tags: `latest` (newest stable) and immutable `X.Y.Z` (pinned). Documented in the README "Docker" section.
+- Official Docker image published to [`docker.io/fsistemas/sql2json`](https://hub.docker.com/r/fsistemas/sql2json), so the tool can be run with `podman run docker.io/fsistemas/sql2json ...` (or `docker run ...`) without building from source. It is now published as a multi-arch image for `linux/amd64` and `linux/arm64`. Supported tags: `latest` (newest stable) and immutable `X.Y.Z` (pinned). Documented in the README "Docker" section.
 
 ### Changed
 - The `Dockerfile` now installs `sql2json` from PyPI (build arg `VERSION` pins a release; omitted installs the latest) instead of copying the working tree, so a tagged image always matches the published release. Its entrypoint is now the `sql2json` console script (was `python -m sql2json`), and it carries OCI image labels.
-- Documented the local (Podman / Docker) image publish + verify step in `RELEASING.md` and CLAUDE.md, run after the PyPI publish.
+- Documented the local (Podman / Docker) image publish + verify step in `RELEASING.md` and CLAUDE.md, run after the PyPI publish. The tested multi-arch local path is rootful Podman (`sudo podman`) with host-level QEMU/binfmt on an amd64 maintainer machine.
 
 ## [0.2.1] - 2026-06-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ uv run --extra dev pytest --cov
 # Run the CLI tool (since 0.2.1; `python -m sql2json ...` is equivalent)
 sql2json --name default --query default
 
+# Run the official Docker Hub image (multi-arch linux/amd64 + linux/arm64)
+podman run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
+# Docker equivalent:
+docker run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
+# Docker Hub: https://hub.docker.com/r/fsistemas/sql2json
+
 # Build the Docker image (installs sql2json from PyPI; pass VERSION to pin a
 # release, omit it for the latest). `podman build ...` works identically.
 docker build -t sql2json .                      # latest PyPI release
@@ -132,7 +138,7 @@ Query values prefixed with `@` are treated as file paths to `.sql` files.
    ```
    `uv build` produces `dist/sql2json-0.1.12.tar.gz` and the wheel. `uv publish` uploads to PyPI (requires a token configured via `UV_PUBLISH_TOKEN` or `~/.pypirc`).
 
-8. **Publish the Docker image** to `docker.io/fsistemas/sql2json` from your local machine (not CI). The image installs `sql2json==<version>` from PyPI, so this runs **after** step 7. The maintainer uses Podman; `docker buildx` is equivalent. Push the immutable `:X.Y.Z` tag every release and move `:latest` only for stable releases. See `RELEASING.md` for the full Podman/Docker commands and the verify step.
+8. **Publish the Docker image** to `docker.io/fsistemas/sql2json` from your local machine (not CI). The image installs `sql2json==<version>` from PyPI, so this runs **after** step 7. The maintainer uses Podman; for multi-arch on an amd64 machine, the tested local path is rootful Podman (`sudo podman`) with host-level `qemu-user-static`/`binfmt_misc`, because rootless Podman can fail to execute arm64 builds. `docker buildx` is equivalent for contributors using real Docker BuildKit. Push the immutable `:X.Y.Z` tag every release and move `:latest` only for stable releases. See `RELEASING.md` for the full Podman/Docker commands and the verify step.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,18 @@ It bundles drivers for PostgreSQL (`psycopg2-binary`) and MySQL / MariaDB
 both `linux/amd64` and `linux/arm64`.
 
 The examples below use [Podman](https://podman.io/); every command works
-identically with `docker` — just swap the executable name.
+identically with `docker` — just swap the executable name. Docker Hub shows the
+current pull command, tags, and supported platforms:
+<https://hub.docker.com/r/fsistemas/sql2json>.
 
 Quick test without a config file (pulls the image on first run):
 
 ```bash
 podman run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
 # → [{"a": 1, "b": 2}]
+
+# Docker equivalent:
+docker run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
 ```
 
 ### Supported tags

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,11 +104,33 @@ requesting one rather than bumping the version yourself.
    ls /proc/sys/fs/binfmt_misc/ | grep qemu-aarch64
    ```
 
-   **Podman** (multi-arch via a manifest list):
+   **Rootful Podman multi-arch publish** (maintainer-tested on Manjaro amd64):
+   if rootless Podman cannot execute arm64 containers, keep local control by
+   using `sudo podman`. Rootful Podman uses separate image storage and registry
+   auth, so log in under `sudo` too.
 
    ```bash
-   podman manifest create docker.io/fsistemas/sql2json:0.2.1
-   podman build --platform linux/amd64,linux/arm64 \
+   sudo podman run --rm --platform linux/arm64 --pull=always \
+     docker.io/library/alpine uname -m
+   # must print: aarch64
+
+   sudo podman login docker.io
+   sudo podman manifest rm docker.io/fsistemas/sql2json:0.2.1 2>/dev/null || true
+   sudo podman build --platform linux/amd64,linux/arm64 --pull=always \
+     --build-arg VERSION=0.2.1 \
+     --manifest docker.io/fsistemas/sql2json:0.2.1 .
+   sudo podman manifest push docker.io/fsistemas/sql2json:0.2.1 \
+     docker.io/fsistemas/sql2json:0.2.1
+   # Stable releases only — also publish the moving `latest` tag:
+   sudo podman manifest push docker.io/fsistemas/sql2json:0.2.1 \
+     docker.io/fsistemas/sql2json:latest
+   ```
+
+   **Rootless Podman** (works only when cross-arch emulation works in the
+   rootless user namespace):
+
+   ```bash
+   podman build --platform linux/amd64,linux/arm64 --pull=always \
      --build-arg VERSION=0.2.1 \
      --manifest docker.io/fsistemas/sql2json:0.2.1 .
    podman manifest push docker.io/fsistemas/sql2json:0.2.1 \

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -137,15 +137,41 @@ sql2json --name mydb --query users --wrapper items     # → {"items": [...]}
 
 ## Docker
 
-Run without installing anything locally:
+Run the official multi-arch image without installing anything locally. The image
+is published on Docker Hub at <https://hub.docker.com/r/fsistemas/sql2json> as
+`docker.io/fsistemas/sql2json` for `linux/amd64` and `linux/arm64`.
 
 ```bash
 # Quick test (built-in SQLite fallback — no config needed)
-docker run --rm sql2json --query "SELECT 1 AS a, 2 AS b"
+podman run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
+# → [{"a": 1, "b": 2}]
 
-# With your config
-docker run --rm -v ~/.sql2json:/root/.sql2json \
-  sql2json --name mydb --query users
+# Docker equivalent
+docker run --rm docker.io/fsistemas/sql2json --query "SELECT 1 AS a, 2 AS b"
+
+# Pin a production/CI release instead of using latest
+podman pull docker.io/fsistemas/sql2json:0.2.1
+```
+
+The container runs as the unprivileged `app` user and reads config from
+`/home/app/.sql2json`:
+
+```bash
+podman run --rm -v ~/.sql2json:/home/app/.sql2json \
+  docker.io/fsistemas/sql2json --name mydb --query users
+```
+
+For release publishing from an amd64 maintainer machine, the known working
+multi-arch path is rootful Podman with host-level QEMU/binfmt:
+
+```bash
+sudo podman run --rm --platform linux/arm64 --pull=always \
+  docker.io/library/alpine uname -m   # must print: aarch64
+sudo podman build --platform linux/amd64,linux/arm64 --pull=always \
+  --build-arg VERSION=0.2.1 \
+  --manifest docker.io/fsistemas/sql2json:0.2.1 .
+sudo podman manifest push docker.io/fsistemas/sql2json:0.2.1 \
+  docker.io/fsistemas/sql2json:0.2.1
 ```
 
 ## Sync strategy


### PR DESCRIPTION
## Summary

Documents the successful local multi-arch Docker image publish path for `sql2json` after the maintainer verified rootful Podman worked cleanly on the existing amd64 Manjaro machine.

- updates README Docker section with Docker Hub pointer plus Podman and Docker run examples
- updates RELEASING.md with the tested `sudo podman` multi-arch publish sequence and rootless fallback notes
- updates CLAUDE.md with Docker Hub usage examples and release guidance
- updates the canonical `skills/sql2json/SKILL.md` Docker guidance and syncs it to local Hermes/Claude skill targets
- updates CHANGELOG to reflect that the image is now multi-arch (`linux/amd64` + `linux/arm64`)

## Verification

- `podman manifest inspect docker.io/fsistemas/sql2json:0.2.1 | grep -E '"architecture"|"os"'` showed both `arm64/linux` and `amd64/linux`
- `git diff --check`
- searched docs for stale amd64-only/rootless-only Docker wording
