### PR TITLE
docs: cross-platform install/upgrade guidance with bundled DB drivers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,58 @@
 
 `sql2json` runs SQL queries via SQLAlchemy and outputs JSON or CSV to stdout. It is invoked as a CLI tool or imported as a Python package — no framework coupling, no MCP server required.
 
-> **Invocation:** examples below use the `sql2json` command, available **since v0.2.1**. On `0.2.0` and earlier — or when the package's scripts directory is not on `PATH` — substitute the equivalent `python -m sql2json ...` form.
+> **Invocation:** examples below use the `sql2json` command, available **since v0.2.1**. On `0.2.0` and earlier — or when the package's scripts directory is not on `PATH` — substitute the equivalent `python -m sql2json ...` form (on Windows, `py -m sql2json ...`).
+
+---
+
+## Install & upgrade (for agents)
+
+Install `sql2json` as an isolated tool, **with the database drivers bundled** so
+queries against PostgreSQL/MySQL work without a follow-up step:
+
+```bash
+uv tool install "sql2json[postgres,mysql]"
+# or
+pipx install "sql2json[postgres,mysql]"
+```
+
+Why these methods matter in a sandbox:
+
+- They work on **externally-managed** environments (Manjaro/Arch, Debian 12+,
+  Ubuntu 23.04+, Homebrew Python), where a plain `pip install` is refused with
+  `error: externally-managed-environment` ([PEP 668](https://peps.python.org/pep-0668/)).
+- They expose `sql2json` on `PATH` (in `~/.local/bin`; run `pipx ensurepath` if
+  it is missing) without mutating any project environment.
+
+**Quote the extras.** In bash/zsh the brackets are glob characters, so the spec
+must be quoted — `"sql2json[postgres,mysql]"` — or the shell expands it and the
+install fails before the installer runs. In PowerShell use single quotes:
+`'sql2json[postgres,mysql]'`.
+
+**Selecting drivers:** `[postgres]` (psycopg2) or `[mysql]` (pymysql) for a
+single database; bare `sql2json` is **SQLite only** — connecting to
+Postgres/MySQL without the extras raises `ModuleNotFoundError: psycopg2` /
+`pymysql`. For other databases (e.g. MS SQL Server's `pyodbc`), install the
+driver alongside: `uv tool install "sql2json" --with pyodbc`.
+
+If `sql2json` already exists but lacks a driver, reinstall with the extras
+(`uv tool install "sql2json[postgres,mysql]" --force`) or inject it
+(`pipx inject sql2json psycopg2-binary pymysql`).
+
+**Inside a project/venv** (library use), add it as a dependency instead, keeping
+the extras: `uv add "sql2json[postgres,mysql]"` or, in an activated venv,
+`pip install "sql2json[postgres,mysql]"`.
+
+**Upgrade** (carry the extras so drivers stay installed):
+
+```bash
+uv tool upgrade sql2json                              # or: uv tool install "sql2json[postgres,mysql]" --force
+pipx upgrade sql2json
+pip install --upgrade "sql2json[postgres,mysql]"      # inside a venv
+```
+
+Check the installed version with `uv tool list`, `pipx list`, or
+`python -c "import importlib.metadata as m; print(m.version('sql2json'))"`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `Dockerfile` now installs `sql2json` from PyPI (build arg `VERSION` pins a release; omitted installs the latest) instead of copying the working tree, so a tagged image always matches the published release. Its entrypoint is now the `sql2json` console script (was `python -m sql2json`), and it carries OCI image labels.
 - Documented the local (Podman / Docker) image publish + verify step in `RELEASING.md` and CLAUDE.md, run after the PyPI publish. The tested multi-arch local path is rootful Podman (`sudo podman`) with host-level QEMU/binfmt on an amd64 maintainer machine.
+- Reworked install/upgrade instructions across `README.md`, `AGENTS.md`, and `skills/sql2json/SKILL.md` to be cross-platform and environment-aware (Linux, macOS, Windows). The recommended install is now an isolated tool (`uv tool install` / `pipx install`) that bundles the Postgres and MySQL drivers by default (`"sql2json[postgres,mysql]"`), works on PEP 668 externally-managed systems, and documents the extras-quoting gotcha, the SQLite-only minimal variant, adding drivers later, the `--break-system-packages` escape hatch, and how to upgrade while keeping the drivers.
 
 ## [0.2.1] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,92 @@ sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 
 ## Install
 
+Published on PyPI: <https://pypi.org/project/sql2json/>
+
+`sql2json` is a CLI tool, so the recommended way to install it is as an
+**isolated tool** that lives on your `PATH` without touching any project
+environment. The default command below also bundles the PostgreSQL and MySQL
+drivers so you can connect to those databases immediately:
+
 ```bash
-pip install sql2json
+uv tool install "sql2json[postgres,mysql]"
+# or
+pipx install "sql2json[postgres,mysql]"
 ```
 
-SQLite works out of the box (it ships with Python). For PostgreSQL or MySQL,
-install the matching driver extra:
+Both methods work on modern, **externally-managed** systems (Manjaro/Arch,
+Debian 12+, Ubuntu 23.04+, Homebrew Python on macOS), where a plain
+system-wide `pip install` is refused with `error: externally-managed-environment`
+([PEP 668](https://peps.python.org/pep-0668/)).
+
+> **Quoting gotcha:** in zsh and bash the square brackets are glob characters,
+> so the package spec **must be quoted** — `"sql2json[postgres,mysql]"`.
+> Unquoted, the shell tries to expand `[postgres,mysql]` and errors before the
+> installer ever runs. In PowerShell quoting is also safest:
+> `pipx install 'sql2json[postgres,mysql]'`.
+
+### As a project dependency (library use)
+
+If you import `sql2json` as a Python package, add it to your project or a
+virtualenv instead — keep the extras:
 
 ```bash
-pip install "sql2json[postgres]"   # psycopg2-binary
-pip install "sql2json[mysql]"      # PyMySQL
+uv add "sql2json[postgres,mysql]"
+# or, inside an activated venv:
 pip install "sql2json[postgres,mysql]"
 ```
 
+### Database drivers (extras)
+
+| Extra | Installs | When you need it |
+|---|---|---|
+| _(none)_ | — | SQLite only (built into Python) |
+| `[postgres]` | `psycopg2-binary` | PostgreSQL |
+| `[mysql]` | `PyMySQL` | MySQL / MariaDB |
+| `[postgres,mysql]` | both | the recommended default |
+
+**Minimal (SQLite only):** a bare install ships no third-party DB drivers —
+fine if you only use SQLite, but connecting to Postgres/MySQL without the extras
+fails with `ModuleNotFoundError: psycopg2` / `pymysql`. Install the extras you
+need:
+
+```bash
+uv tool install sql2json        # SQLite only — add [postgres]/[mysql] for those DBs
+pipx install sql2json           # same, minimal
+```
+
+**Adding drivers later** — if you already installed `sql2json` and now need a
+driver, reinstall with the extras (or inject the driver into the isolated tool):
+
+```bash
+uv tool install "sql2json[postgres,mysql]" --force   # reinstall with drivers
+pipx inject sql2json psycopg2-binary pymysql         # add to the pipx install
+```
+
 Other databases work too — install any
-[SQLAlchemy-supported driver](https://docs.sqlalchemy.org/en/20/dialects/) (e.g.
-`pyodbc` for MS SQL Server) alongside `sql2json`.
+[SQLAlchemy-supported driver](https://docs.sqlalchemy.org/en/20/dialects/)
+alongside `sql2json`. For example, MS SQL Server needs `pyodbc`:
+
+```bash
+uv tool install "sql2json" --with pyodbc
+pipx inject sql2json pyodbc
+```
+
+### Per-OS notes
+
+- **Linux:** system Python is externally-managed (PEP 668). `uv tool` and
+  `pipx` install into `~/.local/bin` — make sure it is on your `PATH`
+  (`pipx ensurepath` sets this up).
+- **macOS:** Homebrew Python is externally-managed too, so prefer `uv tool` /
+  `pipx`; they place scripts on your `PATH` the same way.
+- **Windows:** the `sql2json.exe` console script lands in the Python/uv/pipx
+  Scripts directory — ensure it is on `PATH`, or use `py -m sql2json ...`. In
+  PowerShell and cmd, quote the extras: `'sql2json[postgres,mysql]'`.
+
+> **Escape hatch (avoid):** on an externally-managed system you *can* force a
+> system-wide install with `pip install --break-system-packages "sql2json[postgres,mysql]"`,
+> but this writes into the OS-managed Python and can break system tooling.
+> Prefer `uv tool` / `pipx` (isolated) or a venv instead.
 
 ### Running it
 
@@ -47,15 +117,25 @@ sql2json --name default --query default
 The `sql2json` command is available **since v0.2.1**. The original
 `python -m sql2json ...` form still works and is equivalent — use it on `0.2.0`
 and earlier, or whenever the package is installed but its scripts directory is
-not on your `PATH`.
+not on your `PATH` (on Windows, `py -m sql2json ...`).
 
-For a global, isolated install that puts `sql2json` on your `PATH` without
-touching your project environments:
+### Upgrading
+
+Carry the same extras through so the drivers stay installed:
 
 ```bash
-pipx install sql2json
-# or
-uv tool install sql2json
+uv tool upgrade sql2json                              # uv tool install
+uv tool install "sql2json[postgres,mysql]" --force    # reinstall, refresh drivers
+pipx upgrade sql2json                                 # pipx install
+pip install --upgrade "sql2json[postgres,mysql]"      # inside a venv
+```
+
+Verify the installed version:
+
+```bash
+uv tool list                             # shows isolated tool versions
+pipx list                                # shows pipx-managed versions
+python -c "import importlib.metadata as m; print(m.version('sql2json'))"
 ```
 
 ## Docker

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -15,15 +15,39 @@ metadata:
 
 `sql2json` is a lightweight CLI that runs SQLAlchemy-supported queries and prints JSON, CSV, or Excel output directly to stdout or a file. It works with any project — there is no built-in assumption about which database or schema you are using.
 
-Install once, use from any project:
+Install once as an isolated tool, **with the Postgres and MySQL drivers
+bundled**, and use it from any project:
 
 ```bash
-pip install sql2json
+uv tool install "sql2json[postgres,mysql]"
+# or
+pipx install "sql2json[postgres,mysql]"
+```
+
+These methods work on **externally-managed** systems (Manjaro/Arch, Debian 12+,
+Ubuntu 23.04+, Homebrew Python), where a bare `pip install` is refused with
+`error: externally-managed-environment` ([PEP 668](https://peps.python.org/pep-0668/)),
+and they put `sql2json` on `PATH` without touching project environments.
+
+**Quote the extras** — in bash/zsh the brackets are glob characters, so
+`"sql2json[postgres,mysql]"` must be quoted (PowerShell:
+`'sql2json[postgres,mysql]'`). Bare `sql2json` is **SQLite only**; add
+`[postgres]` and/or `[mysql]` for those databases (other drivers, e.g. `pyodbc`
+for MS SQL, install alongside). For library/project use, add it as a dependency
+instead: `uv add "sql2json[postgres,mysql]"` or, in a venv,
+`pip install "sql2json[postgres,mysql]"`.
+
+**Upgrade** (keep the extras so drivers stay installed):
+
+```bash
+uv tool upgrade sql2json      # or: uv tool install "sql2json[postgres,mysql]" --force
+pipx upgrade sql2json
+pip install --upgrade "sql2json[postgres,mysql]"   # inside a venv
 ```
 
 Examples here use the `sql2json` command, available since **v0.2.1**. On `0.2.0`
 and earlier — or if the command is not on `PATH` — use the equivalent
-`python -m sql2json ...` form instead.
+`python -m sql2json ...` form instead (on Windows, `py -m sql2json ...`).
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

Reworks the install/upgrade instructions across all three doc surfaces — `README.md`, `AGENTS.md`, and `skills/sql2json/SKILL.md` — to be cross-platform and environment-aware (Linux, macOS, Windows). Closes FRA-203.

The old docs led with bare `pip install sql2json`, which fails on modern externally-managed systems ([PEP 668](https://peps.python.org/pep-0668/): Manjaro/Arch, Debian 12+, Ubuntu 23.04+, Homebrew Python) and ships SQLite only — so connecting to Postgres/MySQL hit `ModuleNotFoundError`.

## Changes

- **Recommended install is now an isolated tool with drivers bundled:** `uv tool install "sql2json[postgres,mysql]"` / `pipx install "sql2json[postgres,mysql]"` — works on PEP 668 systems and exposes `sql2json` on `PATH`.
- **Extras-quoting gotcha** documented (brackets are shell globs — must be quoted; PowerShell variant noted).
- **SQLite-only minimal variant** kept and clearly labeled, plus a driver-extras table and how to **add drivers later** (`--force` reinstall / `pipx inject`).
- **Per-OS notes** for Linux, macOS, Windows (PATH, `py -m sql2json`, quoting).
- **`--break-system-packages` escape hatch** documented with why to avoid it.
- **New upgrade section** for `uv tool`, `pipx`, and venv/pip that carries the extras through, with version-verification commands.
- **PyPI link** added to the README.
- CHANGELOG `[Unreleased]` entry.

Also discarded a stale uncommitted local edit to `SKILL.md` that pointed to a `references/rootful-podman-multiarch.md` file which does not exist in the repo.

## Testing

- `uv run pytest` → 127 passed, 12 deselected
- `uv run flake8` → clean

Docs-only change; no code paths touched.