### PR TITLE
Add scoped query discovery

### DIFF
--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -4,6 +4,7 @@ import csv
 import json
 import sys
 from decimal import Decimal
+from typing import Union
 
 import fire
 
@@ -104,7 +105,7 @@ def handle_run_query2json(
     format="json",
     output=None,
     list_connections=False,
-    list_queries=False,
+    list_queries: Union[bool, str] = False,
     timezone=None,
     **kwargs,
 ):
@@ -116,7 +117,14 @@ def handle_run_query2json(
 
         if list_queries:
             config_path = kwargs.get("config")
-            print(json.dumps(_list_queries(config_path)))
+            if isinstance(list_queries, str) and list_queries.lower() in {
+                "legacy",
+                "flat",
+                "names",
+            }:
+                print(json.dumps(_list_queries(config_path)))
+            else:
+                print(json.dumps(_list_queries(config_path, scoped=True)))
             return
 
         result = run_query2json(

--- a/sql2json/sql2json.py
+++ b/sql2json/sql2json.py
@@ -96,11 +96,53 @@ def list_connections(config_path: Optional[str] = None) -> list:
     return list(_get_connections_dict(config).keys())
 
 
-def list_queries(config_path: Optional[str] = None) -> list:
-    """Return the names of all configured queries."""
+def list_queries(
+    config_path: Optional[str] = None,
+    scoped: bool = False,
+    connection: Optional[str] = None,
+) -> Union[list, dict]:
+    """
+    Return configured query names.
+
+    By default this preserves the historical public API and returns only global
+    query names from the top-level ``queries`` object.
+
+    When ``scoped`` is true, return an agent-friendly discovery object that
+    separates top-level global queries from per-connection scoped queries::
+
+        {"global": [...], "connections": {"connection_name": [...]}}
+
+    When ``connection`` is provided, return the effective query names for that
+    connection: global query names plus connection-scoped names, with scoped
+    names appearing only once when they shadow a global query of the same name.
+    """
     path = config_path or _find_config()
     config = load_config_file(path)
-    return list(config.get("queries", {}).keys())
+    global_query_names = list(config.get("queries", {}).keys())
+
+    if not scoped and connection is None:
+        return global_query_names
+
+    connections = _get_connections_dict(config)
+    connection_queries = _get_connection_queries_dict(config, connections)
+
+    if scoped:
+        return {
+            "global": global_query_names,
+            "connections": {
+                connection_name: list(queries.keys())
+                for connection_name, queries in connection_queries.items()
+            },
+        }
+
+    if connection is not None:
+        effective_query_names = list(global_query_names)
+        for query_name in connection_queries.get(connection, {}).keys():
+            if query_name not in effective_query_names:
+                effective_query_names.append(query_name)
+        return effective_query_names
+
+    return global_query_names
 
 
 def _get_connection_queries_dict(config: dict, connections: dict) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,14 +110,45 @@ class TestListQueries:
         result = run_cli("--list-queries", "--config", cfg)
         assert result.returncode == 0
 
-    def test_stdout_is_json_array(self, tmp_path):
+    def test_stdout_exposes_global_and_connection_scoped_queries(self, tmp_path):
+        cfg = str(tmp_path / "config.json")
+        _write_config(
+            cfg,
+            {
+                "connections": {
+                    "default": "sqlite:///:memory:",
+                    "reporting": "sqlite:///:memory:",
+                },
+                "queries": {
+                    "default": "SELECT 1 AS a, 2 AS b",
+                    "sales": "SELECT 42 AS total",
+                },
+                "connection_queries": {
+                    "default": {"sales": "SELECT 7 AS scoped_sales"},
+                    "reporting": {"pipeline": "SELECT 8 AS pipeline"},
+                },
+            },
+        )
+        result = run_cli("--list-queries", "--config", cfg)
+        discovery = json.loads(result.stdout)
+
+        assert discovery == {
+            "global": ["default", "sales"],
+            "connections": {
+                "default": ["sales"],
+                "reporting": ["pipeline"],
+            },
+        }
+
+    def test_legacy_list_queries_output_remains_available(self, tmp_path):
         cfg = str(tmp_path / "config.json")
         _write_config(cfg, CONFIG)
-        result = run_cli("--list-queries", "--config", cfg)
+
+        result = run_cli("--list-queries", "legacy", "--config", cfg)
+
+        assert result.returncode == 0
         names = json.loads(result.stdout)
-        assert isinstance(names, list)
-        assert "default" in names
-        assert "sales" in names
+        assert names == ["default", "sales"]
 
     def test_stderr_is_empty(self, tmp_path):
         cfg = str(tmp_path / "config.json")

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -250,6 +250,11 @@ class TestHandleRunQuery2Json:
 
     def test_list_queries_branch(self, capsys, tmp_path):
         handle_run_query2json(list_queries=True, config=_write_config(tmp_path))
+        discovery = json.loads(capsys.readouterr().out)
+        assert discovery == {"global": ["default", "sales"], "connections": {}}
+
+    def test_list_queries_legacy_branch(self, capsys, tmp_path):
+        handle_run_query2json(list_queries="legacy", config=_write_config(tmp_path))
         names = json.loads(capsys.readouterr().out)
         assert sorted(names) == ["default", "sales"]
 

--- a/tests/test_sql2json.py
+++ b/tests/test_sql2json.py
@@ -130,6 +130,63 @@ def test_run_query_by_name_falls_back_to_global_query(tmp_path):
     assert json_results == [{"global_value": 2}]
 
 
+def test_list_queries_keeps_legacy_global_query_list_by_default(tmp_path):
+    cfg = tmp_path / "config.json"
+    _write_config(
+        cfg,
+        {
+            "connections": {"default": "sqlite:///:memory:"},
+            "queries": {"global": "SELECT 1"},
+            "connection_queries": {"default": {"scoped": "SELECT 2"}},
+        },
+    )
+
+    assert sql2json.list_queries(str(cfg)) == ["global"]
+
+
+def test_list_queries_can_return_scoped_discovery_shape(tmp_path):
+    cfg = tmp_path / "config.json"
+    _write_config(
+        cfg,
+        {
+            "connections": {
+                "default": "sqlite:///:memory:",
+                "reporting": "sqlite:///:memory:",
+            },
+            "queries": {"global": "SELECT 1", "shadowed": "SELECT 'global'"},
+            "connection_queries": {
+                "default": {"shadowed": "SELECT 'scoped'"},
+                "reporting": {"report": "SELECT 2"},
+            },
+        },
+    )
+
+    assert sql2json.list_queries(str(cfg), scoped=True) == {
+        "global": ["global", "shadowed"],
+        "connections": {"default": ["shadowed"], "reporting": ["report"]},
+    }
+
+
+def test_list_queries_can_return_effective_query_names_for_a_connection(tmp_path):
+    cfg = tmp_path / "config.json"
+    _write_config(
+        cfg,
+        {
+            "connections": {"default": "sqlite:///:memory:"},
+            "queries": {"global": "SELECT 1", "shadowed": "SELECT 'global'"},
+            "connection_queries": {
+                "default": {"shadowed": "SELECT 'scoped'", "scoped": "SELECT 2"}
+            },
+        },
+    )
+
+    assert sql2json.list_queries(str(cfg), connection="default") == [
+        "global",
+        "shadowed",
+        "scoped",
+    ]
+
+
 def test_run_query_by_name_scoped_query_takes_precedence_over_global(tmp_path):
     cfg = tmp_path / "config.json"
     _write_config(


### PR DESCRIPTION
## Summary

Adds agent-friendly discovery for connection-scoped queries while preserving legacy public API behavior.

- `--list-queries` now returns a scoped discovery object with global and per-connection query names.
- `--list-queries legacy` keeps the previous flat global-query list output available.
- `list_queries(config_path)` keeps returning global query names by default.
- `list_queries(config_path, scoped=True)` returns global and connection-specific discovery.
- `list_queries(config_path, connection="...")` returns effective query names for a connection with scoped names de-duplicated over globals.

## Verification

- `.venv/bin/python -m pytest tests/test_cli.py::TestListQueries tests/test_sql2json.py::test_list_queries_keeps_legacy_global_query_list_by_default tests/test_sql2json.py::test_list_queries_can_return_scoped_discovery_shape tests/test_sql2json.py::test_list_queries_can_return_effective_query_names_for_a_connection -q` — 7 passed
- `.venv/bin/python -m pytest -q` — 138 passed, 12 deselected
- `.venv/bin/black --check sql2json tests` — passed
- `.venv/bin/flake8 sql2json tests` — passed
- `.venv/bin/python -m mypy sql2json` — passed
