### PR TITLE
feat: add --version/-v flag to sql2json CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Existing `queries` configs remain valid; they are the fallback/global scope. Que
 | `--output` | Save to file instead of printing; filename supports `{CURRENT_DATE}` etc. | `--output report_{CURRENT_DATE}` |
 | `--list-connections` | Print JSON array of configured connection names and exit | `--list-connections` |
 | `--list-queries` | Print configured query names and exit. Default shape is `{"global": [...], "connections": {...}}`; pass `--list-queries legacy` for the old flat global query array | `--list-queries` |
+| `--version` / `-v` | Print the installed version (`sql2json <version>`) and exit | `--version` |
 
 **Note:** Both `--list-connections` and `--list_connections` (underscore) are accepted by fire.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--version` / `-v` flag prints the installed version (`sql2json <version>`) and exits 0, instead of trying to run a query named `version`.
+
 ### Changed
 - The Docker image now uses an Alpine base with a multi-stage build, producing a
   smaller image (~99 MB). It continues to run as a non-root user.

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ sql2json [options] [--param value ...]
 | `--output` | _(stdout)_ | Save to file; filename supports `{CURRENT_DATE}` etc. |
 | `--list-connections` | — | Print JSON array of configured connection names and exit |
 | `--list-queries` | — | Print configured query names and exit. Default shape is `{"global": [...], "connections": {...}}`; pass `--list-queries legacy` for the old flat global query list |
+| `--version` / `-v` | — | Print the installed version (`sql2json <version>`) and exit |
 
 Extra `--key value` flags become SQL bind parameters (`:key` in your query).
 

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -104,6 +104,7 @@ sql2json --list-connections
 sql2json --list-queries
 # → {"global": ["users"], "connections": {"mydb": ["table_sizes"]}}
 sql2json --list-queries legacy   # old flat global query list
+sql2json --version               # print installed version and exit (also -v)
 ```
 
 When an agent receives a data request, discover connections and scoped queries before inventing SQL. Choose a connection, then prefer a query listed under that connection; fall back to a global query only if no scoped query matches.

--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -8,6 +8,7 @@ from typing import Union
 
 import fire
 
+from . import __version__
 from .parameter import parse_parameter
 from .sql2json import (
     _current_date,
@@ -160,6 +161,9 @@ def handle_run_query2json(
 
 
 def main():
+    if any(arg in ("--version", "-v") for arg in sys.argv[1:]):
+        print(f"sql2json {__version__}")
+        sys.exit(0)
     fire.Fire(handle_run_query2json)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,6 +276,48 @@ class TestTimezone:
         assert "error" in error
 
 
+class TestVersion:
+    def test_long_flag_exits_zero(self):
+        result = run_cli("--version")
+        assert result.returncode == 0
+
+    def test_short_flag_exits_zero(self):
+        result = run_cli("-v")
+        assert result.returncode == 0
+
+    def test_long_flag_prints_version(self):
+        from sql2json import __version__
+
+        result = run_cli("--version")
+        assert result.stdout.strip() == f"sql2json {__version__}"
+
+    def test_short_flag_prints_version(self):
+        from sql2json import __version__
+
+        result = run_cli("-v")
+        assert result.stdout.strip() == f"sql2json {__version__}"
+
+    def test_does_not_run_a_query(self):
+        result = run_cli("--version")
+        assert result.stderr == ""
+
+    def test_short_circuits_before_config_is_read(self, tmp_path):
+        from sql2json import __version__
+
+        missing_cfg = str(tmp_path / "does_not_exist.json")
+        result = run_cli("--version", "--config", missing_cfg)
+        assert result.returncode == 0
+        assert result.stdout.strip() == f"sql2json {__version__}"
+        assert result.stderr == ""
+
+    def test_works_alongside_other_flags(self):
+        from sql2json import __version__
+
+        result = run_cli("--name", "default", "--query", "default", "--version")
+        assert result.returncode == 0
+        assert result.stdout.strip() == f"sql2json {__version__}"
+
+
 class TestEntryPoint:
     """The `sql2json` console_scripts entry point (pyproject [project.scripts])."""
 


### PR DESCRIPTION
## Summary

Adds a `--version` / `-v` flag to the `sql2json` CLI. Previously `sql2json --version` tried to run a query named `version` and failed with a config error.

```bash
sql2json --version
# → sql2json 0.3.0
sql2json -v
# → sql2json 0.3.0
```

The check runs in `main()` before `fire.Fire()`, so it short-circuits all normal query execution, prints `sql2json <version>` to stdout, and exits 0. Version comes from the existing `__version__` (`importlib.metadata`).

## Tests

New `TestVersion` class in `tests/test_cli.py` (runs the real CLI as a subprocess):
- `--version` and `-v` each exit 0 and print `sql2json <version>`
- no query runs / stderr is empty
- short-circuits before config is read (works with a missing `--config` path)
- works when combined with other flags (`--name`/`--query`)

Version is asserted against `sql2json.__version__`, so tests survive version bumps. Full suite (145) and flake8 pass.

## Docs

Updated `README.md`, `AGENTS.md`, `skills/sql2json/SKILL.md`, and `CHANGELOG.md` (Unreleased → Added).