### PR TITLE
feat: DML/DDL writes with autocommit and --read-only safe mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ Existing `queries` configs remain valid; they are the fallback/global scope. Que
 | `--value` | Use with `--key` to produce `{key_col: value_col}` dicts | `--value amount` |
 | `--wrapper` | Wrap result in `{"data": [...]}` | `--wrapper` |
 | `--jsonkeys` | Comma-separated columns whose string values should be parsed as JSON | `--jsonkeys payload,metadata` |
+| `--read-only` | Run the statement without persisting anything (DB read-only on SQLite/PostgreSQL/MySQL, rollback backstop elsewhere). Safe for exploration/automation | `--read-only` |
 | `--format` | Output format: `json` (default), `csv`, `excel` | `--format csv` |
 | `--output` | Save to file instead of printing; filename supports `{CURRENT_DATE}` etc. | `--output report_{CURRENT_DATE}` |
 | `--list-connections` | Print JSON array of configured connection names and exit | `--list-connections` |
@@ -153,6 +154,53 @@ Existing `queries` configs remain valid; they are the fallback/global scope. Que
 | `--version` / `-v` | Print the installed version (`sql2json <version>`) and exit | `--version` |
 
 **Note:** Both `--list-connections` and `--list_connections` (underscore) are accepted by fire.
+
+---
+
+## Writing data & `--read-only`
+
+The command **commits by default** (autocommit). It runs any SQL — `SELECT`,
+**DML** (`INSERT` / `UPDATE` / `DELETE` / `MERGE` / `UPSERT`), and **DDL**
+(`CREATE` / `ALTER` / `DROP` / `TRUNCATE`). Writes persist:
+
+```bash
+# SELECT returns rows
+sql2json --name mydb --query "SELECT * FROM users"
+
+# A write commits and reports the affected-row count
+sql2json --name mydb --query "UPDATE users SET active = 1 WHERE id = :id" --id 7
+# → {"rowcount": 1}
+```
+
+| Statement | Output |
+|---|---|
+| SELECT / `... RETURNING` | returns rows, shaped by the transform flags |
+| INSERT / UPDATE / DELETE / DDL (no rows) | persists, prints `{"rowcount": N}` (DDL / count-unknown statements report `{"rowcount": 0}` consistently across databases) |
+
+### `--read-only` (safe mode)
+
+Add `--read-only` to run a statement **without persisting anything**. A real
+database read-only transaction is requested where supported (SQLite, PostgreSQL,
+MySQL) so a write is rejected up front, with an unconditional rollback as the
+portable backstop. A write under `--read-only` reports `{"rowcount": ...}` and
+prints a notice to **stderr** instead of persisting; `SELECT` returns rows
+normally with no notice.
+
+```bash
+# Safe read
+sql2json --read-only --name mydb --query "SELECT * FROM users"
+
+# A write is not persisted under --read-only
+sql2json --read-only --name mydb --query "DELETE FROM users WHERE id = :id" --id 7
+# stdout → {"rowcount": 0}
+# stderr → read-only mode: write not persisted (re-run without --read-only to commit the change).
+```
+
+**Agent guidance:** because the command commits by default, prefer `--read-only`
+for exploration, schema discovery, automation, or any context that must not
+mutate data. Drop the flag only when you intend to persist a write. Note
+`--read-only` still *runs* the statement (then rolls it back / has it rejected),
+so it is not a syntactic guard against destructive SQL.
 
 ---
 
@@ -229,7 +277,12 @@ sql2json --name mysql --query sales_monthly --format csv --output sales_{CURRENT
 ## Python API
 
 ```python
-from sql2json import run_query2json, run_query_by_name, list_connections, list_queries
+from sql2json import (
+    run_query2json,
+    run_query_by_name,
+    list_connections,
+    list_queries,
+)
 
 # Discover what's configured
 connections = list_connections("/path/to/config.json")
@@ -256,9 +309,29 @@ result = run_query2json(
 )
 
 # Python API raises exceptions normally — no error envelope
+
+# Writes commit by default. Non-row statements return {"rowcount": N};
+# SELECT / RETURNING return rows.
+written = run_query2json(
+    name="mysql",
+    query="UPDATE users SET active = 1 WHERE id = :id",
+    id=7,
+    config="/path/to/config.json",
+)
+# → {"rowcount": 1}
+
+# Run a statement without persisting anything (safe mode).
+preview = run_query2json(
+    name="mysql",
+    query="DELETE FROM users WHERE id = :id",
+    id=7,
+    read_only=True,
+    config="/path/to/config.json",
+)
+# nothing persisted; a notice is printed to stderr for a write
 ```
 
-`config` is a special kwarg handled by the library; it is not forwarded to SQLAlchemy as a bind parameter.
+`config` is a special kwarg handled by the library; it is not forwarded to SQLAlchemy as a bind parameter. `run_query_by_name(..., read_only=True)` is the low-level primitive that rolls back instead of committing.
 
 ---
 
@@ -266,4 +339,4 @@ result = run_query2json(
 
 - Validate and scope any SQL before passing it to `--query`. The tool executes whatever SQL it receives.
 - Use named queries from `config.json` when possible to limit the SQL surface.
-- The tool does not enforce read-only access — that is the caller's responsibility.
+- The tool **commits writes by default** (autocommit), so any write it runs persists. For locked-down or agent contexts that must not mutate data, use `--read-only` (or `read_only=True`) — the statement runs but nothing persists. Note `--read-only` still *runs* the statement (rolled back / rejected by the DB), so do not treat it as a syntactic guard against destructive SQL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `--read-only` flag (default off) for an opt-in safe mode: the statement still runs but nothing is persisted. A real database read-only transaction is requested where supported — SQLite (`PRAGMA query_only`), PostgreSQL/MySQL (`SET TRANSACTION READ ONLY`) — so a write is rejected by the database up front, with an unconditional rollback as the portable backstop for any other backend. A write under `--read-only` reports `{"rowcount": ...}` and prints a notice to stderr (`read-only mode: write not persisted ...`) instead of persisting; SELECT returns rows normally. Recommended for agents, automation, and exploration. Also available from Python as `run_query2json(..., read_only=True)`.
 - `--version` / `-v` flag prints the installed version (`sql2json <version>`) and exits 0, instead of trying to run a query named `version`.
 
 ### Changed
+- The default command now commits writes by default (autocommit). INSERT / UPDATE / DELETE / DDL persist and return `{"rowcount": N}` instead of raising `ResourceClosedError`; SELECT / `... RETURNING` return rows shaped by the transform flags. The reported rowcount is clamped to `0` (`max(rowcount, 0)`) so a DDL / "count unknown" statement — which drivers report as `-1` on SQLite/PostgreSQL but `0` on MySQL — yields a consistent `{"rowcount": 0}` across databases. The separate `execute` subcommand and `run_execute2json` helper have been removed — use the default command to write and `--read-only` to avoid persisting.
 - The Docker image now uses an Alpine base with a multi-stage build, producing a
   smaller image (~99 MB). It continues to run as a non-root user.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,14 +50,22 @@ docker build --build-arg VERSION=0.3.0 -t sql2json .
 
 `sql2json` is a CLI tool that runs SQL queries via SQLAlchemy and outputs JSON, CSV, or Excel. Since 0.2.1 it is invoked as the `sql2json` console command (declared in `[project.scripts]`, target `sql2json.__main__:main`); the equivalent `python -m sql2json` form still works. Both dispatch through `fire`.
 
+### One command: autocommit by default, `--read-only` for safe mode
+
+There is a single command (no subcommands). It runs any SQL and **commits by default** (autocommit). It branches on `result.returns_rows`: row-returning statements (SELECT, `... RETURNING`) return rows through the transform pipeline; non-row statements (INSERT/UPDATE/DELETE/DDL) persist and return `{"rowcount": N}`. The rowcount is clamped to `0` (`max(rowcount, 0)`) so a DDL / "count unknown" statement — which drivers report as `-1` on SQLite/PostgreSQL but `0` on MySQL — yields a consistent `{"rowcount": 0}` across databases; real DML counts are `>= 1` and pass through.
+
+`--read-only` (default false) is an opt-in safe mode: the statement still runs but nothing is persisted. Enforcement is hybrid — a real DB read-only transaction is requested where supported (SQLite `PRAGMA query_only = ON`; PostgreSQL/MySQL `SET TRANSACTION READ ONLY`) so a write is rejected up front (reported as `{"rowcount": 0}`, not an error), with an unconditional `con.rollback()` as the portable backstop. A write under `--read-only` prints a notice to stderr and is not persisted; SELECT returns rows normally. `--read-only`/`--read_only` accepts a bare flag or truthy strings (`true/t/yes/y/1/on`) via `_coerce_bool`.
+
+`main()` parses bare flags through `fire`; the only special-cased token is `--version`/`-v`, which prints the version and exits before any query runs.
+
 ### Data flow
 
 ```
 CLI args (fire) → handle_run_query2json() [__main__.py]
-  → run_query2json() [sql2json.py]       # applies result transformations (first/key/value/wrapper/jsonkeys)
-    → run_query_by_name()                # resolves config, loads query by name or from .sql file
-      → run_query()                      # executes via SQLAlchemy, kwargs become SQL :params
-        → parse_parameter() per kwarg   # translates date variable strings to real dates
+  → run_query2json(..., read_only=<bool>) [sql2json.py]   # apply transforms; warn on a read-only write
+    → run_query_by_name(..., read_only=<bool>)            # resolves config, loads query by name or from .sql file
+      → run_query(..., read_only=<bool>)                  # executes via SQLAlchemy; commits (or rolls back when read_only); returns rows or {"rowcount": N}
+        → parse_parameter() per kwarg                      # translates date variable strings to real dates
 ```
 
 Extra `**kwargs` passed on the CLI (e.g. `--date_from CURRENT_DATE-1`) flow through as both SQL bind parameters (`:date_from` in the query) and are resolved by `parse_parameter` before execution.
@@ -89,6 +97,7 @@ Query values prefixed with `@` are treated as file paths to `.sql` files.
 | `--value` | Used with `--key` to produce `{key_col: value_col}` dicts |
 | `--wrapper` | Wrap the result. `True`/bare flag wraps under `{"data": [...]}`; a non-empty string wraps under that key (`--wrapper items` → `{"items": [...]}`); `False`/`""` returns it unwrapped |
 | `--jsonkeys` | Comma-separated column names whose string values should be parsed as JSON |
+| `--read-only` | Opt-in safe mode: the statement runs but nothing persists (DB read-only on SQLite/PostgreSQL/MySQL, rollback backstop elsewhere). A write prints a stderr notice and returns `{"rowcount": ...}` without persisting; SELECT returns rows normally |
 | `--format` | `json` (default), `csv`, or `excel` |
 | `--output` | Save to file instead of printing; filename supports `{CURRENT_DATE}` etc. |
 | `--timezone` | IANA timezone name for resolving date variables (e.g. `UTC`, `America/New_York`). Defaults to local system timezone. |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ sql2json --name mysql --query sales_monthly --date_from "START_CURRENT_MONTH-1"
 # → [{"month": "January", "sales": 5000}, {"month": "February", "sales": 3000}]
 ```
 
+The command commits by default, so writes persist:
+
+```bash
+sql2json --name mysql --query "UPDATE jobs SET done = 1 WHERE id = :id" --id 42
+# → {"rowcount": 1}
+```
+
+Pass `--read-only` to run a statement without persisting anything (safe for exploration and agents).
+
 ## Use cases
 
 - **Scheduled reports**: run a cron job that pulls yesterday's sales and posts the JSON to a dashboard (Geckoboard, Grafana, etc.)
@@ -459,6 +468,60 @@ sql2json --list-queries legacy
 ```
 
 Use the scoped discovery output to choose an appropriate `--name`/`--query` pair. For a given connection, an entry under `connections.<name>` overrides a same-named global query; otherwise the global query is used as a fallback.
+
+## Writing data & read-only mode
+
+There is one command and it **commits by default** (autocommit). It runs any kind
+of SQL — `SELECT`, **DML** (`INSERT` / `UPDATE` / `DELETE`), and **DDL** (`CREATE`
+/ `ALTER` / `DROP`):
+
+| Statement | Result |
+|---|---|
+| `SELECT` / `... RETURNING` | returns rows, shaped by the usual transform flags |
+| INSERT / UPDATE / DELETE / DDL (returns no rows) | persists and prints `{"rowcount": N}` (DDL / count-unknown statements report `{"rowcount": 0}` consistently across databases) |
+
+```bash
+# DDL — create a table (persists)
+sql2json --name mydb --query "CREATE TABLE sessions (id INTEGER, expires_at TEXT)"
+# → {"rowcount": 0}
+
+# DML — delete rows (persists, prints the affected-row count)
+sql2json --name mydb --query "DELETE FROM sessions WHERE expires_at < :cutoff" \
+  --cutoff "CURRENT_DATE-30"
+# → {"rowcount": 12}
+
+# RETURNING streams the new rows back, shaped by the usual flags
+sql2json --name mydb \
+  --query "INSERT INTO users (email) VALUES (:e) RETURNING id, email" --e a@b.com
+# → [{"id": 7, "email": "a@b.com"}]
+```
+
+### `--read-only` (safe mode)
+
+Pass `--read-only` to run a statement **without persisting anything**. The
+statement still executes, but a real database read-only transaction is requested
+where supported — SQLite, PostgreSQL, and MySQL — so a write is rejected by the
+database up front, with an unconditional rollback as a portable backstop for any
+other backend. A write under `--read-only` reports `{"rowcount": ...}` and prints
+a notice to **stderr**, leaving stdout as clean JSON; `SELECT` returns rows as
+usual with no notice.
+
+```bash
+# SELECT under --read-only behaves exactly like a normal read
+sql2json --read-only --name mydb --query "SELECT count(*) AS n FROM users"
+# → [{"n": 1234}]
+
+# A write under --read-only does not persist
+sql2json --read-only --name mydb --query "DELETE FROM users WHERE id = :id" --id 42
+# stdout → {"rowcount": 0}
+# stderr → read-only mode: write not persisted (re-run without --read-only to commit the change).
+```
+
+> **Safety:** because the command commits by default, gate it in locked-down
+> deployments and prefer `--read-only` for agents, automation, and exploration —
+> anywhere that must not mutate data. Note `--read-only` still *runs* the
+> statement (then rolls it back / has it rejected), so it is not a syntactic
+> guard against destructive SQL.
 
 ## Date variables
 

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sql2json
-description: Use when you need to query a SQL database from the terminal with sql2json, especially for live repo DB checks, named queries from ~/.sql2json/config.json, or quick JSON/CSV output from SQLAlchemy-backed connections.
+description: Use when you need to run SQL from the terminal with sql2json — query (SELECT) or write (INSERT/UPDATE/DELETE/DDL, committed by default; use --read-only for safe reads), especially for live repo DB checks, named queries from ~/.sql2json/config.json, or quick JSON/CSV output from SQLAlchemy-backed connections.
 version: 1.0.0
 author: Francisco + Hermes Agent
 license: MIT
@@ -57,10 +57,18 @@ Use this skill when you need to:
 - Execute a one-off SQL statement and get JSON back quickly
 - Pipe database results into `jq`, scripts, or other CLI tools
 - Export query results as CSV or Excel
+- Write to the database (INSERT / UPDATE / DELETE / DDL) — the command commits by default
+
+> **Writes commit by default; use `--read-only` for safe reads.** The command
+> runs any SQL and **commits by default** (autocommit): `SELECT` returns rows,
+> while `INSERT` / `UPDATE` / `DELETE` / DDL persist and return `{"rowcount": N}`.
+> When you only want to read (or must not mutate anything), add `--read-only` —
+> the statement still runs but nothing persists, and a write prints a stderr
+> notice instead of committing. See
+> [Writing data & read-only mode](#writing-data--read-only-mode).
 
 Don't use this skill when:
 
-- You need to mutate data without a clear query
 - You already have a dedicated app-level API that exposes the answer
 - The target database is not reachable
 
@@ -179,6 +187,57 @@ sql2json --name mydb --query users --wrapper items     # → {"items": [...]}
 ```
 
 `--wrapper` (bare) wraps under `"data"`; pass a name (`--wrapper items`) to wrap under that key instead. Omit it for a bare array.
+
+## Writing data & read-only mode
+
+The command **commits by default** (autocommit). It runs any SQL — `SELECT`,
+**DML** (`INSERT`/`UPDATE`/`DELETE`), and **DDL** (`CREATE`/`ALTER`/`DROP`):
+
+- **No-row statements** (INSERT/UPDATE/DELETE/DDL) persist and return `{"rowcount": N}` (DDL / count-unknown statements report `{"rowcount": 0}` consistently across databases).
+- **Row-returning statements** (SELECT, `... RETURNING`) return rows shaped by the transform flags (`--first`, `--key`, `--value`, `--wrapper`, `--jsonkeys`, `--format`, `--output`).
+
+```bash
+# DDL — create a table (persists)
+sql2json --name mydb --query "CREATE TABLE audit (id INTEGER, msg TEXT)"
+# → {"rowcount": 0}
+
+# DML — INSERT / UPDATE / DELETE, persists, prints affected-row count
+sql2json --name mydb --query "INSERT INTO audit (msg) VALUES (:msg)" --msg "hello"
+# → {"rowcount": 1}
+
+# Parameters and date variables work the same way
+sql2json --name mydb \
+  --query "UPDATE jobs SET ran_at = :ts WHERE id = :id" \
+  --ts "CURRENT_DATE|%Y-%m-%d 00:00:00" --id 42
+# → {"rowcount": 1}
+
+# INSERT ... RETURNING streams the new rows back (driver permitting)
+sql2json --name mydb \
+  --query "INSERT INTO users (email) VALUES (:e) RETURNING id, email" --e a@b.com
+# → [{"id": 7, "email": "a@b.com"}]
+```
+
+### `--read-only` (safe mode)
+
+Add `--read-only` to run a statement **without persisting anything**. A real
+database read-only transaction is requested where supported (SQLite, PostgreSQL,
+MySQL) so a write is rejected up front, with an unconditional rollback as the
+portable backstop. A write under `--read-only` returns `{"rowcount": ...}` and
+prints a notice to **stderr**; `SELECT` returns rows normally with no notice.
+Prefer it for exploration, automation, or any context that must not mutate data.
+
+```bash
+# Safe read
+sql2json --read-only --name mydb --query "SELECT count(*) AS n FROM users"
+# → [{"n": 1234}]
+
+# A write is not persisted under --read-only
+sql2json --read-only --name mydb --query "DELETE FROM users WHERE id = :id" --id 7
+# stdout → {"rowcount": 0}
+# stderr → read-only mode: write not persisted (re-run without --read-only to commit the change).
+```
+
+Named queries and `@file.sql` resolve the same way regardless of `--read-only`.
 
 ## Docker
 

--- a/sql2json/__init__.py
+++ b/sql2json/__init__.py
@@ -3,7 +3,12 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from .parameter import parse_parameter
-from .sql2json import list_connections, list_queries, run_query2json, run_query_by_name
+from .sql2json import (
+    list_connections,
+    list_queries,
+    run_query2json,
+    run_query_by_name,
+)
 
 
 def _package_version() -> str:

--- a/sql2json/__main__.py
+++ b/sql2json/__main__.py
@@ -95,6 +95,24 @@ def save_csv(rows, file_name, dialect, key, timezone=None):
             writer.writerow(data)
 
 
+def emit_result(result, format, output, key, value, first, timezone):
+    """Serialize a result to a file (--output) or stdout, honoring --format."""
+    if output:
+        if "csv" == format:
+            save_csv(result, output, "csv", key, timezone=timezone)
+        elif "excel" == format:
+            save_csv(result, output, "excel", key, timezone=timezone)
+        else:
+            save_json(result, output, timezone=timezone)
+    else:
+        if key and value and first:
+            print(json_dumps(result))
+        elif key and first:
+            print(result)
+        else:
+            print(json_dumps(result))
+
+
 def handle_run_query2json(
     name="default",
     query="default",
@@ -108,6 +126,7 @@ def handle_run_query2json(
     list_connections=False,
     list_queries: Union[bool, str] = False,
     timezone=None,
+    read_only=False,
     **kwargs,
 ):
     try:
@@ -137,23 +156,11 @@ def handle_run_query2json(
             value,
             jsonkeys,
             timezone=timezone,
+            read_only=read_only,
             **kwargs,
         )
 
-        if output:
-            if "csv" == format:
-                save_csv(result, output, "csv", key, timezone=timezone)
-            elif "excel" == format:
-                save_csv(result, output, "excel", key, timezone=timezone)
-            else:
-                save_json(result, output, timezone=timezone)
-        else:
-            if key and value and first:
-                print(json_dumps(result))
-            elif key and first:
-                print(result)
-            else:
-                print(json_dumps(result))
+        emit_result(result, format, output, key, value, first, timezone)
 
     except Exception as e:
         print(json.dumps({"error": str(e), "type": type(e).__name__}), file=sys.stderr)

--- a/sql2json/sql2json.py
+++ b/sql2json/sql2json.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import sys
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -21,13 +22,108 @@ def map_result_proxy2list_dict(result_proxy) -> list:
     return [dict(zip(keys, row)) for row in result_proxy]
 
 
-def run_query(engine, raw_query: str, timezone: Optional[str] = None, **kwargs) -> list:
+_TRUTHY_STRINGS = {"true", "t", "yes", "y", "1", "on"}
+
+
+def _coerce_bool(value) -> bool:
+    """
+    Coerce a CLI/string value to a bool.
+
+    fire passes a bare flag (``--read-only``) as ``True`` but a value form
+    (``--read-only yes``) through as the string ``"yes"``; this normalizes both,
+    accepting ``true``/``t``/``yes``/``y``/``1``/``on`` (case-insensitive) as true.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY_STRINGS
+    return bool(value)
+
+
+def _begin_read_only(con) -> None:
+    """
+    Best-effort: put the live connection into a real read-only transaction where
+    the backend supports it, so a write is rejected by the database *before* it
+    runs (no triggers, no side effects). Verified on SQLite and PostgreSQL;
+    other backends are caught by the unconditional rollback in run_query, which
+    is the portable backstop, so any failure here is intentionally swallowed.
+    """
+    dialect = con.engine.dialect.name
+    try:
+        if dialect == "sqlite":
+            con.exec_driver_sql("PRAGMA query_only = ON")
+        elif dialect in ("postgresql", "mysql", "mariadb"):
+            con.exec_driver_sql("SET TRANSACTION READ ONLY")
+    except Exception:
+        pass
+
+
+def _is_read_only_violation(exc: Exception) -> bool:
+    """True when a database error is a read-only / write-blocked rejection."""
+    message = str(getattr(exc, "orig", exc)).lower()
+    return "readonly" in message or "read only" in message or "read-only" in message
+
+
+def run_query(
+    engine,
+    raw_query: str,
+    timezone: Optional[str] = None,
+    read_only: bool = False,
+    **kwargs,
+) -> Union[list, dict]:
+    """
+    Execute a single SQL statement and return its result.
+
+    Row-returning statements (SELECT, ``... RETURNING``) yield a list of dicts.
+    Statements that return no rows (INSERT / UPDATE / DELETE without RETURNING,
+    DDL) yield ``{"rowcount": N}`` instead of raising. ``returns_rows`` is used
+    to tell the two apart — more robust than sniffing the SQL string.
+
+    Writes are committed by default (autocommit). When ``read_only`` is true the
+    statement runs without persisting: a real read-only transaction is requested
+    where the backend supports it (SQLite/PostgreSQL/MySQL) so a write is
+    rejected up front, and the transaction is *always* rolled back as a portable
+    backstop. A rejected write is reported as ``{"rowcount": 0}`` rather than
+    raising, so read-only mode never hard-fails on a write.
+    """
+    read_only = _coerce_bool(read_only)
     current_date = _current_date(timezone)
     parameters = {k: parse_parameter(v, current_date) for k, v in kwargs.items()}
 
     with engine.connect() as con:
-        result_proxy = con.execute(text(raw_query), parameters)
-        records = map_result_proxy2list_dict(result_proxy)
+        if read_only:
+            _begin_read_only(con)
+
+        try:
+            result_proxy = con.execute(text(raw_query), parameters)
+
+            if result_proxy.returns_rows:
+                records: Union[list, dict] = map_result_proxy2list_dict(result_proxy)
+            else:
+                # Clamp to 0 for a consistent contract across drivers: a DDL /
+                # "count unknown" statement reports -1 on SQLite/PostgreSQL but 0
+                # on MySQL, so normalize any non-positive value to 0. Real DML
+                # affected-row counts are >= 1 and pass through unchanged.
+                records = {"rowcount": max(result_proxy.rowcount, 0)}
+        except Exception as exc:
+            # Real read-only guard: the database rejected the write. Surface the
+            # same soft "nothing persisted" result as the rollback fallback
+            # instead of a hard error.
+            if read_only and _is_read_only_violation(exc):
+                con.rollback()
+                return {"rowcount": 0}
+            raise
+        finally:
+            # PRAGMA query_only is connection-scoped; clear it so a pooled
+            # SQLite connection is not left read-only for later reuse.
+            if read_only and con.engine.dialect.name == "sqlite":
+                try:
+                    con.exec_driver_sql("PRAGMA query_only = OFF")
+                except Exception:
+                    pass
+
+        if read_only:
+            con.rollback()
+        else:
+            con.commit()
 
     return records
 
@@ -188,14 +284,18 @@ def _resolve_query_string(
 
 def run_query_by_name(
     conection_name: str = "default", query_name: str = "default", **kwargs
-) -> list:
+) -> Union[list, dict]:
     """
     Run a SQL query given a conection_name, query_name.
-    Returns a list of dicts.
+
+    Returns a list of dicts for row-returning statements, or ``{"rowcount": N}``
+    for statements that return no rows. Writes commit by default; pass
+    ``read_only=True`` to roll back instead (the statement still runs).
     """
-    # Pop config and timezone before passing kwargs to SQLAlchemy so they aren't treated as bind params
+    # Pop config, timezone and read_only before passing kwargs to SQLAlchemy so they aren't treated as bind params
     config_path = kwargs.pop("config", None) or _find_config()
     timezone = kwargs.pop("timezone", None)
+    read_only = kwargs.pop("read_only", False)
 
     config = load_config_file(config_path)
 
@@ -213,7 +313,9 @@ def run_query_by_name(
 
     engine = create_engine(conection_string)
 
-    return run_query(engine, raw_query_string, timezone=timezone, **kwargs)
+    return run_query(
+        engine, raw_query_string, timezone=timezone, read_only=read_only, **kwargs
+    )
 
 
 def parse_json_columns(result: dict, jsonkeys: str = "") -> dict:
@@ -242,33 +344,35 @@ def parse_json_columns(result: dict, jsonkeys: str = "") -> dict:
     return response
 
 
-def run_query2json(
-    name: str = "default",
-    query: str = "default",
+def apply_wrapper(
+    result: Union[str, dict, list], wrapper: Union[bool, str] = False
+) -> Union[str, dict, list]:
+    """
+    Wrap a result under a top-level key.
+
+    A non-empty string wraps under that key (e.g. "items" -> {"items": ...});
+    True wraps under "data" ({"data": ...}); False or "" returns it unwrapped.
+    """
+    if isinstance(wrapper, str) and wrapper:
+        return {wrapper: result}
+    elif wrapper:
+        return {"data": result}
+    return result
+
+
+def apply_output_transforms(
+    unparsed_results: list,
     wrapper: Union[bool, str] = False,
     first: bool = False,
     key: str = "",
     value: str = "",
     jsonkeys: str = "",
-    timezone: Optional[str] = None,
-    **kwargs,
 ) -> Union[str, dict, list]:
     """
-    Run a SQL query and return results with optional transformations.
-
-    name: Connection name in config file or a SQLAlchemy connection string.
-    query: Query name in config file, raw SQL, or @/path/to/file.sql.
-    wrapper: Wrap result list. True wraps under "data" ({"data": [...]}); a
-        non-empty string wraps under that key (e.g. "items" -> {"items": [...]});
-        False or "" returns the result unwrapped.
-    first: Return only the first row.
-    key: Column name to use as key (with value) or extract as scalar (with first).
-    value: Column name to use as value (used with key).
-    jsonkeys: Comma-separated columns whose string values should be parsed as JSON.
-    timezone: IANA timezone name used to resolve CURRENT_DATE and related variables (e.g. "America/New_York"). Defaults to local system timezone.
+    Apply the row-shaping (first/key/value/jsonkeys) and wrapper transforms to a
+    list of row dicts. Shared by both the read (``query``) and write (``execute``)
+    code paths so row-returning output is identical across commands.
     """
-    unparsed_results = run_query_by_name(name, query, timezone=timezone, **kwargs)
-
     results = [parse_json_columns(result, jsonkeys) for result in unparsed_results]
 
     result: Union[str, dict, list, None] = None
@@ -298,9 +402,66 @@ def run_query2json(
                 item.get(key) if key and key in item else item for item in results
             ]
 
-    if isinstance(wrapper, str) and wrapper:
-        return {wrapper: result}
-    elif wrapper:
-        return {"data": result}
-    else:
-        return result
+    return apply_wrapper(result, wrapper)
+
+
+def _warn_read_only_write(result: dict) -> None:
+    """
+    Print a friendly notice (on stderr, so stdout stays clean JSON) when a write
+    statement is run under ``--read-only``. The write is never persisted — it is
+    rejected by the database where supported, and always rolled back as a
+    backstop — so this replaces the old hard failure with a clear explanation.
+    """
+    print(
+        "read-only mode: write not persisted "
+        "(re-run without --read-only to commit the change).",
+        file=sys.stderr,
+    )
+
+
+def run_query2json(
+    name: str = "default",
+    query: str = "default",
+    wrapper: Union[bool, str] = False,
+    first: bool = False,
+    key: str = "",
+    value: str = "",
+    jsonkeys: str = "",
+    timezone: Optional[str] = None,
+    read_only: bool = False,
+    **kwargs,
+) -> Union[str, dict, list]:
+    """
+    Run a SQL statement and return results with optional transformations.
+
+    Writes commit by default (autocommit): an INSERT / UPDATE / DELETE / DDL
+    statement persists and returns ``{"rowcount": N}``, while SELECT /
+    ``... RETURNING`` return rows shaped by the transform flags. Pass
+    ``read_only=True`` to roll the statement back instead — it still executes but
+    nothing is persisted, and a notice is printed to stderr for write statements.
+
+    name: Connection name in config file or a SQLAlchemy connection string.
+    query: Query name in config file, raw SQL, or @/path/to/file.sql.
+    wrapper: Wrap result. True wraps under "data" ({"data": ...}); a non-empty
+        string wraps under that key (e.g. "items" -> {"items": ...}); False or ""
+        returns the result unwrapped.
+    first: Return only the first row.
+    key: Column name to use as key (with value) or extract as scalar (with first).
+    value: Column name to use as value (used with key).
+    jsonkeys: Comma-separated columns whose string values should be parsed as JSON.
+    timezone: IANA timezone name used to resolve CURRENT_DATE and related variables (e.g. "America/New_York"). Defaults to local system timezone.
+    read_only: When true, roll back instead of committing (statement still runs).
+    """
+    read_only = _coerce_bool(read_only)
+    result = run_query_by_name(
+        name, query, timezone=timezone, read_only=read_only, **kwargs
+    )
+
+    # A non-row-returning statement (INSERT / UPDATE / DELETE / DDL) comes back
+    # as {"rowcount": N}; row shaping does not apply, but the wrapper still does.
+    if isinstance(result, dict):
+        if read_only:
+            _warn_read_only_write(result)
+        return apply_wrapper(result, wrapper)
+
+    return apply_output_transforms(result, wrapper, first, key, value, jsonkeys)

--- a/tests/integration/test_databases.py
+++ b/tests/integration/test_databases.py
@@ -1,9 +1,11 @@
 """Real-database integration tests for the documented demo paths.
 
 Covers, for both PostgreSQL and MySQL: named connection lookup, named query
-lookup, bind parameters, numeric/Decimal values, and end-to-end JSON
-serialization through the CLI. Marked `integration` (deselected by default);
-see tests/integration/conftest.py for provisioning and clean-skip behavior.
+lookup, bind parameters, numeric/Decimal values, end-to-end JSON serialization
+through the CLI, and the write path — autocommit persistence and `--read-only`
+rejection via `SET TRANSACTION READ ONLY` (the branch the SQLite unit tests
+cannot exercise). Marked `integration` (deselected by default); see
+tests/integration/conftest.py for provisioning and clean-skip behavior.
 """
 
 import json
@@ -81,3 +83,120 @@ def test_cli_json_serialization_decimal_to_float(database):
     by_month = {r["month"]: r["amount"] for r in json.loads(result.stdout)}
     assert by_month["January"] == 5000.0
     assert isinstance(by_month["January"], float)
+
+
+# Table used by the write tests; created/dropped per test so the shared demo
+# database is left clean and tests do not depend on ordering.
+_WRITE_TABLE = "s2j_write_it"
+
+
+@pytest.fixture
+def write_table(database):
+    """Provide a fresh, empty write table and drop it afterwards.
+
+    Yields the same `database` dict the other tests use. The autocommit-by-default
+    path is what persists the CREATE here, so the fixture also exercises it.
+    """
+    name, config = database["name"], database["config"]
+    run_query2json(name, f"DROP TABLE IF EXISTS {_WRITE_TABLE}", config=config)
+    run_query2json(name, f"CREATE TABLE {_WRITE_TABLE} (id INTEGER)", config=config)
+    try:
+        yield database
+    finally:
+        run_query2json(name, f"DROP TABLE IF EXISTS {_WRITE_TABLE}", config=config)
+
+
+def _count(database):
+    rows = run_query2json(
+        database["name"],
+        f"SELECT COUNT(*) AS n FROM {_WRITE_TABLE}",
+        config=database["config"],
+    )
+    return rows[0]["n"]
+
+
+def test_ddl_rowcount_is_zero(database):
+    """DDL reports {"rowcount": 0} on every backend (drivers vary: -1 on PG, 0 on
+    MySQL), so the clamp gives a consistent contract."""
+    name, config = database["name"], database["config"]
+    run_query2json(name, "DROP TABLE IF EXISTS s2j_ddl", config=config)
+    try:
+        result = run_query2json(
+            name, "CREATE TABLE s2j_ddl (id INTEGER)", config=config
+        )
+        assert result == {"rowcount": 0}
+    finally:
+        run_query2json(name, "DROP TABLE IF EXISTS s2j_ddl", config=config)
+
+
+def test_insert_commits_by_default(write_table):
+    """A bare INSERT persists across a separate invocation and reports rowcount."""
+    result = run_query2json(
+        write_table["name"],
+        f"INSERT INTO {_WRITE_TABLE} VALUES (1)",
+        config=write_table["config"],
+    )
+    assert result == {"rowcount": 1}
+    assert _count(write_table) == 1
+
+
+def test_update_returns_affected_rowcount(write_table):
+    """UPDATE reports the affected-row count and persists."""
+    for i in (1, 2, 3):
+        run_query2json(
+            write_table["name"],
+            f"INSERT INTO {_WRITE_TABLE} VALUES ({i})",
+            config=write_table["config"],
+        )
+    result = run_query2json(
+        write_table["name"],
+        f"UPDATE {_WRITE_TABLE} SET id = id + 10 WHERE id > 1",
+        config=write_table["config"],
+    )
+    assert result == {"rowcount": 2}
+
+
+def test_read_only_insert_is_rejected_and_not_persisted(write_table):
+    """`SET TRANSACTION READ ONLY` rejects the write; nothing persists."""
+    result = run_query2json(
+        write_table["name"],
+        f"INSERT INTO {_WRITE_TABLE} VALUES (99)",
+        read_only=True,
+        config=write_table["config"],
+    )
+    # The DB rejects the write, reported as a soft rowcount dict (not an error).
+    assert isinstance(result, dict) and "rowcount" in result
+    assert _count(write_table) == 0
+
+
+def test_read_only_select_returns_rows(write_table):
+    """SELECT under --read-only behaves like a normal read."""
+    run_query2json(
+        write_table["name"],
+        f"INSERT INTO {_WRITE_TABLE} VALUES (1)",
+        config=write_table["config"],
+    )
+    rows = run_query2json(
+        write_table["name"],
+        f"SELECT id FROM {_WRITE_TABLE}",
+        read_only=True,
+        config=write_table["config"],
+    )
+    assert rows == [{"id": 1}]
+
+
+def test_cli_read_only_write_warns_on_stderr(write_table):
+    """End-to-end CLI: a write under --read-only prints the stderr notice."""
+    result = run_cli(
+        "--read-only",
+        "--name",
+        write_table["name"],
+        "--query",
+        f"INSERT INTO {_WRITE_TABLE} VALUES (5)",
+        "--config",
+        write_table["config"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "read-only mode: write not persisted" in result.stderr
+    json.loads(result.stdout)  # stdout stays clean JSON
+    assert _count(write_table) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,6 +318,58 @@ class TestVersion:
         assert result.stdout.strip() == f"sql2json {__version__}"
 
 
+class TestWriteAndReadOnly:
+    """The default command commits writes; `--read-only` is opt-in safe mode."""
+
+    def _file_db_config(self, tmp_path):
+        db = tmp_path / "test.db"
+        cfg = str(tmp_path / "config.json")
+        _write_config(
+            cfg,
+            {"connections": {"default": f"sqlite:///{db}"}, "queries": {}},
+        )
+        return cfg
+
+    def test_default_insert_persists_across_invocations(self, tmp_path):
+        cfg = self._file_db_config(tmp_path)
+        r1 = run_cli("--query", "CREATE TABLE t (id INTEGER)", "--config", cfg)
+        r2 = run_cli("--query", "INSERT INTO t VALUES (1)", "--config", cfg)
+        r3 = run_cli("--query", "SELECT COUNT(*) AS n FROM t", "--config", cfg)
+        assert r1.returncode == 0
+        assert r2.returncode == 0
+        assert r3.returncode == 0
+        assert json.loads(r3.stdout) == [{"n": 1}]
+
+    def test_read_only_insert_does_not_persist(self, tmp_path):
+        cfg = self._file_db_config(tmp_path)
+        run_cli("--query", "CREATE TABLE t (id INTEGER)", "--config", cfg)
+        ro = run_cli(
+            "--read-only", "--query", "INSERT INTO t VALUES (1)", "--config", cfg
+        )
+        assert ro.returncode == 0
+        # stdout is still valid JSON (a rowcount dict)
+        json.loads(ro.stdout)
+        assert "read-only mode: write not persisted" in ro.stderr
+
+        result = run_cli("--query", "SELECT COUNT(*) AS n FROM t", "--config", cfg)
+        assert json.loads(result.stdout) == [{"n": 0}]
+
+    def test_read_only_select_returns_rows(self, tmp_path):
+        cfg = str(tmp_path / "config.json")
+        _write_config(cfg, CONFIG)
+        result = run_cli("--read-only", "--query", "SELECT 7 AS v", "--config", cfg)
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == [{"v": 7}]
+
+    def test_bad_sql_exits_nonzero_with_json_error(self, tmp_path):
+        cfg = self._file_db_config(tmp_path)
+        result = run_cli("--query", "INSERT INTO nope VALUES (1)", "--config", cfg)
+        assert result.returncode != 0
+        assert result.stdout == ""
+        error = json.loads(result.stderr)
+        assert "error" in error and "type" in error
+
+
 class TestEntryPoint:
     """The `sql2json` console_scripts entry point (pyproject [project.scripts])."""
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,0 +1,213 @@
+"""
+Unit tests for the write path (autocommit by default) and the ``--read-only``
+safe mode.
+
+These run in-process. Persistence is verified against a *file-based* SQLite
+database in tmp_path (a ``sqlite:///:memory:`` URL would give each new engine its
+own empty database, so it cannot show that a commit survived across calls).
+"""
+
+import json
+
+import pytest
+
+from sql2json import run_query2json, run_query_by_name
+from sql2json.sql2json import _coerce_bool
+
+
+def _file_db_config(tmp_path):
+    """Write a config mapping the `db` connection to a file-backed SQLite DB."""
+    db = tmp_path / "test.db"
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "connections": {"db": f"sqlite:///{db}"},
+                "queries": {},
+            }
+        )
+    )
+    return str(cfg)
+
+
+class TestAutocommitPersistence:
+    def test_create_table_returns_rowcount(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        # DDL rowcount is clamped to 0 for a consistent cross-database contract
+        # (drivers report -1 on SQLite/PostgreSQL, 0 on MySQL).
+        assert result == {"rowcount": 0}
+
+    def test_insert_persists_and_returns_rowcount(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER, name TEXT)", config=cfg)
+        result = run_query2json(
+            "db", "INSERT INTO t (id, name) VALUES (1, 'a')", config=cfg
+        )
+        assert result == {"rowcount": 1}
+
+        rows = run_query2json("db", "SELECT COUNT(*) AS n FROM t", config=cfg)
+        assert rows == [{"n": 1}]
+
+    def test_update_returns_affected_rowcount(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER, name TEXT)", config=cfg)
+        run_query2json("db", "INSERT INTO t VALUES (1, 'a')", config=cfg)
+        run_query2json("db", "INSERT INTO t VALUES (2, 'a')", config=cfg)
+        result = run_query2json(
+            "db", "UPDATE t SET name = 'b' WHERE name = 'a'", config=cfg
+        )
+        assert result == {"rowcount": 2}
+
+    def test_delete_returns_affected_rowcount(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        run_query2json("db", "INSERT INTO t VALUES (1)", config=cfg)
+        run_query2json("db", "INSERT INTO t VALUES (2)", config=cfg)
+        result = run_query2json("db", "DELETE FROM t WHERE id = 1", config=cfg)
+        assert result == {"rowcount": 1}
+
+    def test_parameterized_insert_persists(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        result = run_query2json(
+            "db", "INSERT INTO t (id) VALUES (:id)", id=7, config=cfg
+        )
+        assert result == {"rowcount": 1}
+
+        rows = run_query2json("db", "SELECT id FROM t", config=cfg)
+        assert rows == [{"id": 7}]
+
+    def test_insert_with_date_variable_persists(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (d TEXT)", config=cfg)
+        run_query2json(
+            "db",
+            "INSERT INTO t (d) VALUES (:d)",
+            d="CURRENT_DATE|%Y-%m-%d",
+            timezone="UTC",
+            config=cfg,
+        )
+        rows = run_query2json("db", "SELECT d FROM t", config=cfg)
+        # A real date string was bound, not the literal "CURRENT_DATE" token.
+        assert rows[0]["d"] != "CURRENT_DATE"
+        assert len(rows[0]["d"]) == 10
+
+    def test_run_query_by_name_no_row_statement_persists(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query_by_name("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        result = run_query_by_name("db", "INSERT INTO t VALUES (1)", config=cfg)
+        assert result == {"rowcount": 1}
+        rows = run_query_by_name("db", "SELECT COUNT(*) AS n FROM t", config=cfg)
+        assert rows == [{"n": 1}]
+
+
+class TestSelectTransforms:
+    def test_first_and_key_returns_scalar(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json("db", "SELECT 5 AS n", first=True, key="n", config=cfg)
+        assert result == 5
+
+    def test_key_value_returns_dict_list(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json(
+            "db", "SELECT 1 AS id, 'a' AS name", key="id", value="name", config=cfg
+        )
+        assert result == [{1: "a"}]
+
+    def test_wrapper_true_wraps_rows_under_data(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json("db", "SELECT 1 AS a", wrapper=True, config=cfg)
+        assert result == {"data": [{"a": 1}]}
+
+    def test_wrapper_string_wraps_rows_under_named_key(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json("db", "SELECT 1 AS a", wrapper="items", config=cfg)
+        assert result == {"items": [{"a": 1}]}
+
+
+class TestWrapperOnRowcount:
+    def test_wrapper_true_wraps_rowcount_under_data(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        result = run_query2json(
+            "db", "INSERT INTO t VALUES (1)", wrapper=True, config=cfg
+        )
+        assert result == {"data": {"rowcount": 1}}
+
+    def test_wrapper_string_wraps_rowcount_under_named_key(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        result = run_query2json(
+            "db", "INSERT INTO t VALUES (1)", wrapper="result", config=cfg
+        )
+        assert result == {"result": {"rowcount": 1}}
+
+
+class TestReadOnly:
+    def test_read_only_write_does_not_persist(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+
+        result = run_query2json(
+            "db", "INSERT INTO t VALUES (1)", read_only=True, config=cfg
+        )
+        # On SQLite the DB rejects the write, so rowcount is 0; on other backends
+        # the rollback backstop applies. Either way it is a rowcount dict and
+        # nothing persists — assert robustly.
+        assert isinstance(result, dict)
+        assert "rowcount" in result
+
+        rows = run_query2json("db", "SELECT COUNT(*) AS n FROM t", config=cfg)
+        assert rows == [{"n": 0}]
+
+    def test_read_only_select_returns_rows(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        result = run_query2json(
+            "db", "SELECT 1 AS a, 2 AS b", read_only=True, config=cfg
+        )
+        assert result == [{"a": 1, "b": 2}]
+
+    def test_read_only_write_warns_on_stderr(self, tmp_path, capsys):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+        run_query2json("db", "INSERT INTO t VALUES (1)", read_only=True, config=cfg)
+
+        captured = capsys.readouterr()
+        assert "read-only mode: write not persisted" in captured.err
+        assert captured.out == ""  # notice never touches stdout
+
+    def test_read_only_select_does_not_warn(self, tmp_path, capsys):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "SELECT 1 AS a", read_only=True, config=cfg)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_read_only_does_not_leak_across_calls(self, tmp_path):
+        cfg = _file_db_config(tmp_path)
+        run_query2json("db", "CREATE TABLE t (id INTEGER)", config=cfg)
+
+        # A read-only write first (SQLite sets PRAGMA query_only on a pooled conn)...
+        run_query2json("db", "INSERT INTO t VALUES (1)", read_only=True, config=cfg)
+
+        # ...a subsequent normal write must still persist (proves no leak/reset works).
+        run_query2json("db", "INSERT INTO t VALUES (2)", config=cfg)
+        rows = run_query2json("db", "SELECT COUNT(*) AS n FROM t", config=cfg)
+        assert rows == [{"n": 1}]
+
+
+class TestCoerceBool:
+    @pytest.mark.parametrize(
+        "value",
+        [True, "true", "t", "yes", "y", "1", "on", "YES"],
+    )
+    def test_truthy(self, value):
+        assert _coerce_bool(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [False, "", "false", "no", "n", "0", "off", None],
+    )
+    def test_falsy(self, value):
+        assert _coerce_bool(value) is False


### PR DESCRIPTION
## Summary

Adds write support to the single default command and an opt-in safe mode.

- **Autocommit writes**: INSERT/UPDATE/DELETE/DDL now commit by default and return `{"rowcount": N}` (previously raised `ResourceClosedError`). SELECT / `... RETURNING` return rows through the transform pipeline as before.
- **Consistent rowcount**: clamped with `max(rowcount, 0)`, so DDL / "count unknown" statements report `{"rowcount": 0}` uniformly across SQLite, PostgreSQL and MySQL (drivers otherwise vary: `-1` vs `0`).
- **`--read-only` safe mode** (default off): the statement runs but nothing persists — a real read-only transaction is requested where supported (SQLite `PRAGMA query_only`, PG/MySQL `SET TRANSACTION READ ONLY`) with an unconditional rollback backstop. A write prints a stderr notice and returns a rowcount dict without persisting; SELECT returns rows normally.

## Tests

- Unit tests on file-backed SQLite (`tests/test_write.py`) for autocommit persistence, read-only, wrapper-on-rowcount, and `_coerce_bool`.
- Integration tests for the write + read-only path against real **PostgreSQL** and **MySQL**, including the `SET TRANSACTION READ ONLY` branch and DDL rowcount consistency.
- Read-only verified live across sqlite/postgres/mysql.

## Docs

README, AGENTS.md, CLAUDE.md, SKILL.md and CHANGELOG updated for the autocommit + `--read-only` contract.