### PR TITLE
Add Pi skill sync support

### DIFF
--- a/docs/skill-sync.md
+++ b/docs/skill-sync.md
@@ -8,6 +8,7 @@ Supported agent skill locations:
 
 - Hermes: `~/.hermes/skills/productivity/sql2json/SKILL.md`
 - Claude: `~/.claude/skills/sql2json/SKILL.md`
+- Pi: `~/.pi/agent/skills/sql2json/SKILL.md`
 
 Refresh everything with:
 
@@ -23,5 +24,5 @@ or, to force-link every configured target regardless of presence checks:
 
 Notes:
 
-- The install script detects which agent roots exist and only installs into those locations.
+- The install script detects which global agent roots exist and only installs into those locations.
 - The sync script force-refreshes all known targets and is useful after editing the canonical skill.

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -7,7 +7,7 @@ canonical="$repo_root/skills/sql2json/SKILL.md"
 agents=(
   "hermes:$HOME/.hermes/skills/productivity/sql2json/SKILL.md"
   "claude:$HOME/.claude/skills/sql2json/SKILL.md"
-  "repo-claude:$repo_root/.claude/skills/sql2json/SKILL.md"
+  "pi:$HOME/.pi/agent/skills/sql2json/SKILL.md"
 )
 
 installed=()
@@ -18,7 +18,7 @@ for entry in "${agents[@]}"; do
   target="${entry#*:}"
   base_dir="$(dirname "$(dirname "$target")")"
 
-  if [[ "$name" == repo-claude || -d "$base_dir" || -e "$base_dir" ]]; then
+  if [[ -d "$base_dir" || -e "$base_dir" ]]; then
     mkdir -p "$(dirname "$target")"
     ln -sfn "$canonical" "$target"
     installed+=("$name")

--- a/scripts/sync-sql2json-skill.sh
+++ b/scripts/sync-sql2json-skill.sh
@@ -7,7 +7,7 @@ canonical="$repo_root/skills/sql2json/SKILL.md"
 targets=(
   "$HOME/.hermes/skills/productivity/sql2json/SKILL.md"
   "$HOME/.claude/skills/sql2json/SKILL.md"
-  "$repo_root/.claude/skills/sql2json/SKILL.md"
+  "$HOME/.pi/agent/skills/sql2json/SKILL.md"
 )
 
 for target in "${targets[@]}"; do

--- a/skills/sql2json/SKILL.md
+++ b/skills/sql2json/SKILL.md
@@ -300,6 +300,7 @@ Supported agent targets:
 |---|---|
 | Hermes | `~/.hermes/skills/productivity/sql2json/SKILL.md` |
 | Claude | `~/.claude/skills/sql2json/SKILL.md` |
+| Pi | `~/.pi/agent/skills/sql2json/SKILL.md` |
 
 See `docs/skill-sync.md` for the full agent-target map.
 


### PR DESCRIPTION
## Summary
- add Pi's global skill path to the skill install/sync scripts
- document the Pi global skill target in skill sync docs and the sql2json skill
- keep skill installation global-only (no project-local Pi target)

## Tests
- bash -n scripts/install-skills.sh
- bash -n scripts/sync-sql2json-skill.sh
- ./scripts/install-skills.sh
- uv run pytest